### PR TITLE
chore(release): cut 0.1.0 — first PyPI publish

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ergon-framework-python"
-version = "0.1.1"
+version = "0.1.0"
 description = "Ergon internal task-oriented project bootstrapper"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Reset version 0.1.1 -> 0.1.0 since this is the first ergon-framework-python release on PyPI; jumping straight to 0.1.1 would leave a confusing gap in the published version history. All previously squashed-in fixes (ack/nack on AsyncConnector ABC, queue_arguments forwarding for DLX, pre-commit ruff bump, asyncio_mode=auto) ship as part of 0.1.0 itself.

Made-with: Cursor