### PR TITLE
docs(0.1.1): fix broken relative links in PyPI README

### DIFF
--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -20,7 +20,7 @@ For local development, install in editable mode:
 pip install -e /path/to/ergon-framework/sdks/python
 ```
 
-📖 **[Full Getting Started Guide](docs/getting-started.md)** — Complete setup, project configuration, and task registration
+📖 **[Full Getting Started Guide](https://github.com/danzanellovossos/ergon-framework/blob/main/sdks/python/docs/getting-started.md)** — Complete setup, project configuration, and task registration
 
 ---
 
@@ -384,7 +384,7 @@ my-project/
         └── helpers.py       # Task-specific utilities
 ```
 
-📖 **[Full Project Structure Guide](docs/project-structure.md)** — Detailed documentation on organizing connectors, tasks, and shared modules.
+📖 **[Full Project Structure Guide](https://github.com/danzanellovossos/ergon-framework/blob/main/sdks/python/docs/project-structure.md)** — Detailed documentation on organizing connectors, tasks, and shared modules.
 
 ---
 
@@ -392,23 +392,23 @@ my-project/
 
 ### Python SDK Guides
 
-- **[Getting Started](docs/getting-started.md)** — Installation, project setup, and running your first task
-- **[CLI Reference](docs/cli.md)** — Commands, options, and exit codes
-- **[Project Structure Guide](docs/project-structure.md)** — How to organize connectors, tasks, and shared modules
+- **[Getting Started](https://github.com/danzanellovossos/ergon-framework/blob/main/sdks/python/docs/getting-started.md)** — Installation, project setup, and running your first task
+- **[CLI Reference](https://github.com/danzanellovossos/ergon-framework/blob/main/sdks/python/docs/cli.md)** — Commands, options, and exit codes
+- **[Project Structure Guide](https://github.com/danzanellovossos/ergon-framework/blob/main/sdks/python/docs/project-structure.md)** — How to organize connectors, tasks, and shared modules
 
 ### Framework Concepts
 
-- **[Framework Architecture](../../docs/architecture.md)** — Full system specification and design philosophy
-- **[Transaction Abstraction](../../docs/modules/1.transaction.md)** — Understanding atomicity rules
-- **[Task Module](../../docs/modules/2.task.md)** — Mixins, lifecycles, and execution modes
-- **[Connector Module](../../docs/modules/3.connector.md)** — Building integration boundaries
-- **[Service Module](../../docs/modules/4.service.md)** — Protocol engineering and reliability
-- **[Telemetry Module](../../docs/modules/5.telemetry.md)** — Configuring OTel logs, metrics, and traces
+- **[Framework Architecture](https://github.com/danzanellovossos/ergon-framework/blob/main/docs/architecture.md)** — Full system specification and design philosophy
+- **[Transaction Abstraction](https://github.com/danzanellovossos/ergon-framework/blob/main/docs/modules/1.transaction.md)** — Understanding atomicity rules
+- **[Task Module](https://github.com/danzanellovossos/ergon-framework/blob/main/docs/modules/2.task.md)** — Mixins, lifecycles, and execution modes
+- **[Connector Module](https://github.com/danzanellovossos/ergon-framework/blob/main/docs/modules/3.connector.md)** — Building integration boundaries
+- **[Service Module](https://github.com/danzanellovossos/ergon-framework/blob/main/docs/modules/4.service.md)** — Protocol engineering and reliability
+- **[Telemetry Module](https://github.com/danzanellovossos/ergon-framework/blob/main/docs/modules/5.telemetry.md)** — Configuring OTel logs, metrics, and traces
 
 ---
 
 ## License
 
-This project is licensed under the [MIT License](../../LICENSE).
+This project is licensed under the [MIT License](https://github.com/danzanellovossos/ergon-framework/blob/main/LICENSE).
 
 <br/>

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ergon-framework-python"
-version = "0.1.0"
+version = "0.1.1"
 description = "Ergon internal task-oriented project bootstrapper"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/src/ergon/__init__.py
+++ b/sdks/python/src/ergon/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "manager",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/sdks/python/tests/test_smoke.py
+++ b/sdks/python/tests/test_smoke.py
@@ -4,4 +4,4 @@ import ergon
 
 
 def test_ergon_package_is_importable() -> None:
-    assert ergon.__version__ == "0.1.0"
+    assert ergon.__version__ == "0.1.1"


### PR DESCRIPTION
PyPI renders README.md as standalone HTML and cannot resolve relative paths, so all 12 docs/license links in sdks/python/README.md were 404'ing on https://pypi.org/project/ergon-framework-python/. Replace each with an absolute GitHub URL pinned to /blob/main/ so improvements to docs continue to flow to PyPI users on latest.

No logic changes; bumps version 0.1.0 -> 0.1.1 in pyproject.toml and ergon.__version__ (with corresponding smoke test update).

Made-with: Cursor