### PR TITLE
fix(rabbitmq): deterministic consumer recovery (zombie consumer + channel leak)

### DIFF
--- a/sdks/python/src/ergon/connector/rabbitmq/async_connector.py
+++ b/sdks/python/src/ergon/connector/rabbitmq/async_connector.py
@@ -116,5 +116,14 @@ class AsyncRabbitMQConnector(AsyncConnector):
             raise ValueError(f"Cannot nack transaction {transaction.id}: no raw message in metadata")
         await self.service.nack(raw_message, requeue=requeue)
 
+    def health(self) -> Dict[str, Any]:
+        """Consumer liveness snapshot (last fetch/ack, active tag, channel state).
+
+        Intended for wiring a service-level health check that can detect a
+        wedged or zombie consumer rather than silently running after a broker
+        cancel.
+        """
+        return self.service.health()
+
     async def close(self) -> None:
         await self.service.close()

--- a/sdks/python/src/ergon/connector/rabbitmq/async_service.py
+++ b/sdks/python/src/ergon/connector/rabbitmq/async_service.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import ssl as ssl_module
+import time
 from typing import Any, Callable, Dict, List, Optional
 
 import aio_pika
@@ -31,6 +32,15 @@ _DEAD_CHANNEL_EXCEPTIONS: tuple[type[BaseException], ...] = (
     aiormq.exceptions.ChannelInvalidStateError,
 )
 
+# Same as above plus ``TimeoutError`` (raised by ``asyncio.timeout`` when an
+# ack/nack stalls on a half-open socket). A stalled ack is functionally a dead
+# channel: we tear down and let the broker redeliver instead of blocking until
+# the heartbeat eventually fires.
+_DEAD_CHANNEL_TIMEOUT_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    *_DEAD_CHANNEL_EXCEPTIONS,
+    TimeoutError,
+)
+
 
 class AsyncRabbitMQService:
     def __init__(self, client: AsyncRabbitmqClient) -> None:
@@ -48,6 +58,13 @@ class AsyncRabbitMQService:
         # in-flight prefetch.
         self._exchanges: Dict[str, AbstractExchange] = {}
         self._queues: Dict[str, AbstractQueue] = {}
+
+        # Liveness signals so services can wire a real health check instead of
+        # silently running with a zombie/dead consumer. Updated on every
+        # successful fetch/ack and reset when the consume channel is torn down.
+        self._last_fetch_ts: Optional[float] = None
+        self._last_ack_ts: Optional[float] = None
+        self._active_consumer_tag: Optional[str] = None
 
     # ---------- Connection / Channel ----------
 
@@ -89,6 +106,61 @@ class AsyncRabbitMQService:
         self._queues.clear()
         self._exchanges.clear()
 
+    async def _teardown_consume_channel(self, reason: str = "explicit teardown") -> None:
+        """Deterministically tear down the consume channel.
+
+        Unlike :meth:`_invalidate_consume_channel` (which only drops Python
+        references), this snapshots the live channel, clears the cache, then
+        explicitly ``close()``-es the channel. Closing the channel:
+
+        * drops every consumer registered on it at the broker — this is what
+          eliminates the *zombie consumer* left behind by a broker-initiated
+          ``Basic.Cancel`` that the per-fetch iterator could not cancel
+          cleanly; and
+        * for a ``RobustChannel`` removes it from aio_pika's reconnection set,
+          so the robust layer does not silently restore the dead consumer on
+          the next reconnect.
+
+        It also prevents the channel leak: previously the dropped channel
+        object was orphaned without ever being closed, so its broker-side
+        channel lingered and ``ChannelCount`` climbed over time.
+        """
+        channel = self._consume_channel
+        self._invalidate_consume_channel(reason)
+        self._active_consumer_tag = None
+        await self._close_channel_safely(channel, reason)
+
+    async def _close_channel_safely(self, channel: Optional[AbstractChannel], reason: str) -> None:
+        """Best-effort close of a (possibly already-dead) channel."""
+        if channel is None:
+            return
+        try:
+            if not channel.is_closed:
+                await channel.close()
+                logger.info("Closed dead consume channel (%s)", reason)
+        except Exception as exc:  # noqa: BLE001 - best-effort teardown
+            logger.warning("Error closing consume channel during teardown (%s): %r", reason, exc)
+
+    def _schedule_teardown(self, reason: str) -> None:
+        """Tear down the consume channel from a sync callback context.
+
+        ``add_close_callback`` / consumer-cancel callbacks are synchronous, so
+        we cannot ``await``. We invalidate the cache synchronously (so the next
+        consume never sees a stale channel) and, when a running event loop is
+        available, schedule the explicit ``close()`` as a task to drop the dead
+        channel's consumers at the broker and avoid the channel leak.
+        """
+        channel = self._consume_channel
+        self._invalidate_consume_channel(reason)
+        self._active_consumer_tag = None
+        if channel is None or channel.is_closed:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        loop.create_task(self._close_channel_safely(channel, reason))
+
     def _on_consume_channel_close(self, *args: Any, **kwargs: Any) -> None:
         """Callback registered with ``channel.add_close_callback``.
 
@@ -97,7 +169,7 @@ class AsyncRabbitMQService:
         """
         exc = args[1] if len(args) >= 2 else kwargs.get("exc")
         reason = f"channel closed: {exc!r}" if exc is not None else "channel closed"
-        self._invalidate_consume_channel(reason)
+        self._schedule_teardown(reason)
 
     async def _get_consume_channel(self, prefetch_count: Optional[int] = None) -> AbstractChannel:
         if self._consume_channel is None or self._consume_channel.is_closed:
@@ -246,24 +318,32 @@ class AsyncRabbitMQService:
             async with asyncio.timeout(timeout):  # type: ignore[attr-defined]
                 async with queue.iterator(no_ack=config.auto_ack) as iterator:
                     self._register_consumer_cancel_callback(iterator)
+                    # Surface the active consumer tag for liveness diagnostics;
+                    # attribute name varies across aio_pika versions.
+                    self._active_consumer_tag = getattr(iterator, "_consumer_tag", None) or getattr(
+                        iterator, "consumer_tag", None
+                    )
                     async for message in iterator:
                         msg_dict = self._message_to_dict(message)
                         buffer.append(msg_dict)
+                        self._last_fetch_ts = time.time()
                         if len(buffer) >= batch_size:
                             break
         except TimeoutError:
             pass
         except _DEAD_CHANNEL_EXCEPTIONS as exc:
-            # Broker cancelled this subscription mid-iteration; invalidate
-            # the cached channel so the next call rebuilds against a fresh
-            # consumer and the broker redelivers what we had prefetched.
-            self._invalidate_consume_channel(f"consume aborted: {exc!r}")
+            # Broker cancelled this subscription mid-iteration; deterministically
+            # tear down (cancel consumers + close) the dead channel so the next
+            # call rebuilds against a fresh consumer, the broker redelivers what
+            # we had prefetched, and no zombie consumer / leaked channel is left
+            # behind.
+            await self._teardown_consume_channel(f"consume aborted: {exc!r}")
             return buffer
         finally:
             # If the channel was closed during iteration, make sure we don't
             # hand back a stale cache to the next caller.
             if self._consume_channel is not None and self._consume_channel.is_closed:
-                self._invalidate_consume_channel("consume channel observed closed after iteration")
+                await self._teardown_consume_channel("consume channel observed closed after iteration")
 
         return buffer
 
@@ -290,7 +370,7 @@ class AsyncRabbitMQService:
             return
 
         def _on_cancel(*_args: Any, **_kwargs: Any) -> None:
-            self._invalidate_consume_channel("consumer cancelled by broker (Basic.Cancel)")
+            self._schedule_teardown("consumer cancelled by broker (Basic.Cancel)")
 
         try:
             candidate(_on_cancel)
@@ -373,9 +453,13 @@ class AsyncRabbitMQService:
         from ...task import exceptions as task_exceptions
 
         try:
-            await message.ack()
-        except _DEAD_CHANNEL_EXCEPTIONS as exc:
-            self._invalidate_consume_channel(f"ack failed: {exc!r}")
+            # Bound the ack so a half-open socket is detected in seconds rather
+            # than blocking until the (much longer) heartbeat timeout fires.
+            async with asyncio.timeout(self.client.ack_timeout):  # type: ignore[attr-defined]
+                await message.ack()
+            self._last_ack_ts = time.time()
+        except _DEAD_CHANNEL_TIMEOUT_EXCEPTIONS as exc:
+            await self._teardown_consume_channel(f"ack failed: {exc!r}")
             raise task_exceptions.AckOnDeadChannelError(
                 delivery_tag=getattr(message, "delivery_tag", None),
                 queue=getattr(message, "routing_key", None),
@@ -386,14 +470,38 @@ class AsyncRabbitMQService:
         from ...task import exceptions as task_exceptions
 
         try:
-            await message.nack(requeue=requeue)
-        except _DEAD_CHANNEL_EXCEPTIONS as exc:
-            self._invalidate_consume_channel(f"nack failed: {exc!r}")
+            async with asyncio.timeout(self.client.ack_timeout):  # type: ignore[attr-defined]
+                await message.nack(requeue=requeue)
+        except _DEAD_CHANNEL_TIMEOUT_EXCEPTIONS as exc:
+            await self._teardown_consume_channel(f"nack failed: {exc!r}")
             raise task_exceptions.NackOnDeadChannelError(
                 delivery_tag=getattr(message, "delivery_tag", None),
                 queue=getattr(message, "routing_key", None),
                 cause=exc,
             ) from exc
+
+    # ---------- Health / Liveness ----------
+
+    def health(self) -> Dict[str, Any]:
+        """Snapshot of consumer liveness for external health checks.
+
+        Exposes the timestamps of the last successful fetch and ack, the active
+        consumer tag, and connection/channel state so a service can detect a
+        wedged or zombie consumer (e.g. no successful ack within N seconds)
+        instead of silently running for hours after a broker cancel.
+        """
+        now = time.time()
+        connection_open = self._connection is not None and not self._connection.is_closed
+        consume_channel_open = self._consume_channel is not None and not self._consume_channel.is_closed
+        return {
+            "connection_open": connection_open,
+            "consume_channel_open": consume_channel_open,
+            "active_consumer_tag": self._active_consumer_tag,
+            "last_fetch_ts": self._last_fetch_ts,
+            "last_ack_ts": self._last_ack_ts,
+            "seconds_since_last_fetch": (now - self._last_fetch_ts) if self._last_fetch_ts is not None else None,
+            "seconds_since_last_ack": (now - self._last_ack_ts) if self._last_ack_ts is not None else None,
+        }
 
     # ---------- Lifecycle ----------
 

--- a/sdks/python/src/ergon/connector/rabbitmq/models.py
+++ b/sdks/python/src/ergon/connector/rabbitmq/models.py
@@ -51,7 +51,22 @@ class AsyncRabbitmqClient(BaseModel):
     username: str = Field(default="guest", description="RabbitMQ username")
     password: str = Field(default="guest", description="RabbitMQ password")
     virtual_host: str = Field(default="/", description="RabbitMQ virtual host")
-    heartbeat: int = Field(default=600, description="Heartbeat interval in seconds")
+    heartbeat: int = Field(
+        default=60,
+        description=(
+            "Heartbeat interval in seconds. Kept low (default 60) so a half-open "
+            "socket is detected within ~2x heartbeat instead of blocking for many "
+            "minutes. AmazonMQ/RabbitMQ negotiate the lower of client/server values."
+        ),
+    )
+    ack_timeout: float = Field(
+        default=30,
+        description=(
+            "Max seconds to wait for an ack/nack RPC before treating the channel as "
+            "dead. Bounds recovery so a stalled ack on a half-open connection fails "
+            "fast (broker redelivers) rather than wedging the consumer."
+        ),
+    )
     connection_attempts: int = Field(default=3, description="Connection retry attempts")
     ssl_enabled: bool = Field(default=False, description="Enable SSL/TLS")
     ssl_ca_certs: Optional[str] = Field(default=None, description="Path to CA certificate when using SSL")
@@ -67,7 +82,15 @@ class AsyncRabbitmqConsumerConfig(BaseModel):
     exchange_name: str = Field(default="", description="Exchange name (empty for default exchange)")
     exchange_type: str = Field(default="topic", description="Exchange type: topic, direct, fanout, headers")
     binding_keys: list[str] = Field(default=["#"], description="Routing key patterns for queue binding")
-    prefetch_count: int = Field(default=10, description="Number of unacknowledged messages allowed")
+    prefetch_count: int = Field(
+        default=10,
+        description=(
+            "Number of unacknowledged messages allowed. Recommended: set equal to the "
+            "consumer loop concurrency. A prefetch larger than concurrency lets idle "
+            "sibling messages sit unacked until they age past the broker "
+            "consumer_timeout, which triggers a Basic.Cancel and consumer recovery."
+        ),
+    )
     durable: bool = Field(default=True, description="Durable exchange and queue declarations")
     auto_ack: bool = Field(default=False, description="Automatically acknowledge messages on delivery")
     consume_timeout: float = Field(default=2.0, description="Max seconds to wait per fetch call")

--- a/sdks/python/src/ergon/task/mixins/consumer.py
+++ b/sdks/python/src/ergon/task/mixins/consumer.py
@@ -45,6 +45,34 @@ def _wrap_handler_failure(result: Any) -> exceptions.TransactionException:
     )
 
 
+def _warn_if_prefetch_exceeds_concurrency(conn: Any, policy: policies.ConsumerPolicy, task_name: str) -> None:
+    """Warn when a broker consumer holds more unacked messages than it can process.
+
+    A prefetch larger than the loop concurrency lets idle sibling messages sit
+    unacked until they age past the broker ``consumer_timeout``, which triggers
+    a ``Basic.Cancel`` and the whole consumer-recovery path. The connector
+    cannot see the loop concurrency and the policy cannot see the connector's
+    prefetch, so the check lives here where both are visible. Best-effort:
+    silently skips connectors that do not expose a consumer config.
+    """
+    consumer_config = getattr(conn, "_consumer_config", None)
+    prefetch = getattr(consumer_config, "prefetch_count", None)
+    if not isinstance(prefetch, int):
+        return
+    concurrency = policy.loop.concurrency.value
+    if prefetch > concurrency:
+        logger.warning(
+            "[%s] prefetch_count=%d exceeds loop concurrency=%d: up to %d messages will be "
+            "held unacked while only %d are processed concurrently. Idle siblings can age past "
+            "the broker consumer_timeout and trigger a Basic.Cancel. Set prefetch_count == concurrency.",
+            task_name,
+            prefetch,
+            concurrency,
+            prefetch,
+            concurrency,
+        )
+
+
 class ConsumerMixin(ABC):
     name: str
     connectors: dict[str, connector.Connector]
@@ -702,6 +730,7 @@ class AsyncConsumerMixin(ABC):
             logger.debug(f"Consume loop running with loop policy: {policy.loop.model_dump_json(indent=2)}")
 
             conn = self._resolve_connector(policy.fetch.connector_name)
+            _warn_if_prefetch_exceeds_concurrency(conn, policy, getattr(self, "name", self.__class__.__name__))
 
             ctx = otel_context.Context()
 

--- a/sdks/python/tests/connector/rabbitmq/test_async_service.py
+++ b/sdks/python/tests/connector/rabbitmq/test_async_service.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import time
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -61,6 +62,12 @@ class TestClientUrl:
     def test_explicit_url_takes_precedence(self):
         client = _make_client(url="amqp://other:other@rmq:5673/vhost")
         assert client.get_url() == "amqp://other:other@rmq:5673/vhost"
+
+    def test_heartbeat_and_ack_timeout_defaults_fail_fast(self):
+        """Defaults must be low enough to detect a half-open socket in seconds."""
+        client = _make_client()
+        assert client.heartbeat == 60
+        assert client.ack_timeout == 30
 
 
 class TestConnection:
@@ -414,6 +421,65 @@ class TestDeadChannelAckNack:
         assert service._queues == {}
         assert service._exchanges == {}
 
+    async def test_ack_on_dead_channel_closes_channel(self):
+        """Teardown must explicitly close the dead channel (kills zombie + leak)."""
+        msg = _mock_message(delivery_tag=7)
+        msg.ack = AsyncMock(side_effect=aio_pika.exceptions.MessageProcessError("dead", None))
+        service = AsyncRabbitMQService(_make_client())
+        dead_channel = _mock_channel()
+        dead_channel.close = AsyncMock()
+        service._consume_channel = dead_channel
+
+        with pytest.raises(AckOnDeadChannelError):
+            await service.ack(msg)
+
+        dead_channel.close.assert_awaited_once()
+        assert service._consume_channel is None
+        assert service._active_consumer_tag is None
+
+    async def test_ack_timeout_raises_dead_channel_and_tears_down(self):
+        """A stalled ack (half-open socket) must fail fast as a dead channel."""
+
+        async def _slow_ack():
+            await asyncio.sleep(1)
+
+        msg = _mock_message(delivery_tag=11)
+        msg.ack = _slow_ack
+        service = AsyncRabbitMQService(_make_client(ack_timeout=0.05))
+        dead_channel = _mock_channel()
+        dead_channel.close = AsyncMock()
+        service._consume_channel = dead_channel
+
+        with pytest.raises(AckOnDeadChannelError):
+            await service.ack(msg)
+
+        dead_channel.close.assert_awaited_once()
+        assert service._consume_channel is None
+
+    async def test_ack_success_records_liveness(self):
+        msg = _mock_message()
+        service = AsyncRabbitMQService(_make_client())
+        assert service._last_ack_ts is None
+        await service.ack(msg)
+        assert service._last_ack_ts is not None
+
+    async def test_teardown_consume_channel_closes_and_clears(self):
+        service = AsyncRabbitMQService(_make_client())
+        ch = _mock_channel()
+        ch.close = AsyncMock()
+        service._consume_channel = ch
+        service._queues["q"] = MagicMock()
+        service._exchanges["x"] = MagicMock()
+        service._active_consumer_tag = "ctag-1"
+
+        await service._teardown_consume_channel("test")
+
+        ch.close.assert_awaited_once()
+        assert service._consume_channel is None
+        assert service._queues == {}
+        assert service._exchanges == {}
+        assert service._active_consumer_tag is None
+
     async def test_nack_on_dead_channel_raises_typed_error(self):
         msg = _mock_message(delivery_tag=99)
         msg.nack = AsyncMock(side_effect=aio_pika.exceptions.MessageProcessError("dead", None))
@@ -458,6 +524,7 @@ class TestDeadChannelAckNack:
     async def test_channel_close_callback_invalidates_consume_channel_only(self):
         service = AsyncRabbitMQService(_make_client())
         consume_ch = _mock_channel()
+        consume_ch.close = AsyncMock()
         publish_ch = _mock_channel()
         service._consume_channel = consume_ch
         service._publish_channel = publish_ch
@@ -465,7 +532,8 @@ class TestDeadChannelAckNack:
         service._exchanges["x"] = MagicMock()
 
         # Simulate aio_pika invoking the close callback that we registered
-        # in ``_get_consume_channel``.
+        # in ``_get_consume_channel``. The cache must be invalidated
+        # synchronously; the explicit close is scheduled on the loop.
         service._on_consume_channel_close(consume_ch, ConnectionError("bye"))
 
         assert service._consume_channel is None
@@ -473,6 +541,11 @@ class TestDeadChannelAckNack:
         assert service._exchanges == {}
         # Publish channel and its state must survive a consume-side outage.
         assert service._publish_channel is publish_ch
+
+        # Let the scheduled teardown task run; it must close the dead channel
+        # so the broker drops its consumers and the channel does not leak.
+        await asyncio.sleep(0)
+        consume_ch.close.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -524,3 +597,29 @@ class TestChannelSplit:
         # Publish must have used a fresh, independent channel — never
         # reused the invalidated consume channel.
         assert service._publish_channel is publish_ch
+
+
+# ---------------------------------------------------------------------------
+# Liveness / health surface
+# ---------------------------------------------------------------------------
+
+
+class TestHealth:
+    async def test_health_reports_initial_state(self):
+        service = AsyncRabbitMQService(_make_client())
+        health = service.health()
+        assert health["connection_open"] is False
+        assert health["consume_channel_open"] is False
+        assert health["active_consumer_tag"] is None
+        assert health["last_fetch_ts"] is None
+        assert health["last_ack_ts"] is None
+        assert health["seconds_since_last_ack"] is None
+
+    async def test_health_reports_elapsed_since_ack(self):
+        service = AsyncRabbitMQService(_make_client())
+        service._last_ack_ts = time.time() - 5
+        service._active_consumer_tag = "ctag-9"
+        health = service.health()
+        assert health["active_consumer_tag"] == "ctag-9"
+        assert health["seconds_since_last_ack"] is not None
+        assert health["seconds_since_last_ack"] >= 5

--- a/sdks/python/tests/task/mixins/test_async_consumer.py
+++ b/sdks/python/tests/task/mixins/test_async_consumer.py
@@ -396,3 +396,59 @@ class TestConnectorResolution:
 
         with pytest.raises(ValueError):
             await consumer.consume_transactions(policy=policy)
+
+
+# =====================================================================
+#   Prefetch vs concurrency guardrail (#6)
+# =====================================================================
+
+
+class TestPrefetchGuardrail:
+    async def test_warns_when_prefetch_exceeds_concurrency(self, caplog):
+        import logging
+
+        from ergon.connector.rabbitmq.models import AsyncRabbitmqConsumerConfig
+        from ergon.task.mixins.consumer import _warn_if_prefetch_exceeds_concurrency
+
+        class _FakeConn:
+            _consumer_config = AsyncRabbitmqConsumerConfig(queue_name="agents.processor", prefetch_count=40)
+
+        policy = policies.ConsumerPolicy()
+        policy.loop.concurrency.value = 20
+
+        with caplog.at_level(logging.WARNING, logger="ergon.task.mixins.consumer"):
+            _warn_if_prefetch_exceeds_concurrency(_FakeConn(), policy, "EventWorkerTask")
+
+        assert any("exceeds loop concurrency" in r.getMessage() for r in caplog.records)
+
+    async def test_no_warning_when_aligned(self, caplog):
+        import logging
+
+        from ergon.connector.rabbitmq.models import AsyncRabbitmqConsumerConfig
+        from ergon.task.mixins.consumer import _warn_if_prefetch_exceeds_concurrency
+
+        class _FakeConn:
+            _consumer_config = AsyncRabbitmqConsumerConfig(queue_name="q", prefetch_count=20)
+
+        policy = policies.ConsumerPolicy()
+        policy.loop.concurrency.value = 20
+
+        with caplog.at_level(logging.WARNING, logger="ergon.task.mixins.consumer"):
+            _warn_if_prefetch_exceeds_concurrency(_FakeConn(), policy, "task")
+
+        assert not any("exceeds loop concurrency" in r.getMessage() for r in caplog.records)
+
+    async def test_skips_connector_without_consumer_config(self, caplog):
+        import logging
+
+        from ergon.task.mixins.consumer import _warn_if_prefetch_exceeds_concurrency
+
+        class _FakeConn:
+            pass
+
+        policy = policies.ConsumerPolicy()
+
+        with caplog.at_level(logging.WARNING, logger="ergon.task.mixins.consumer"):
+            _warn_if_prefetch_exceeds_concurrency(_FakeConn(), policy, "task")
+
+        assert not any("exceeds loop concurrency" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary

Fixes the production incident where the RabbitMQ consumer silently stopped responding for ~hours after a broker-initiated `Basic.Cancel`, leaving a zombie consumer, leaking broker channels, and stalling for ~30 min.

Root cause: on a channel-invalid / broker cancel, the connector only dropped Python references and never cancelled/closed the dead channel. With `connect_robust`, the robust layer restored the old consumer while the next fetch subscribed again -> 2 consumers on the queue (broker round-robins, half the messages sit unacked forever). Orphaned-but-unclosed channels leaked at the broker, and a 600s heartbeat masked the half-open socket for ~20 min.

### Changes
- **Deterministic teardown + leak fix:** new `_teardown_consume_channel` / `_close_channel_safely` explicitly `close()` the dead channel (drops broker-side consumers, removes a `RobustChannel` from the reconnection set). Used in `consume()`, `ack()`, `nack()`.
- **Fail fast:** heartbeat default `600 -> 60`, new `ack_timeout` (30s), and `ack`/`nack` wrapped in `asyncio.timeout` so a stalled ack on a half-open socket is treated as a dead channel instead of blocking.
- **Hardened cancel callbacks:** invalidate the cache synchronously and schedule the explicit close on the running loop.
- **Prefetch guardrail (#6):** warn when `prefetch_count > loop concurrency` (the condition that ages sibling messages past the broker `consumer_timeout` and triggers the cancel) + doc recommending `prefetch == concurrency`.
- **Liveness surface (#7):** track last fetch/ack timestamps and active consumer tag; expose `service.health()` and `connector.health()`.

Items #5 (pre-process channel-validity check) and #8 (explicit re-declare) are intentionally left as follow-ups (cross-layer / already largely handled by cache invalidation).

## Test plan
- [x] `uv run pytest tests/connector/rabbitmq tests/task/mixins -q` (117 passed)
- [x] Full suite: `uv run pytest -q` (200 passed)
- [x] New tests: teardown-closes-channel, ack timeout -> `AckOnDeadChannelError`, heartbeat/ack_timeout defaults, `health()` snapshots, prefetch guardrail (warns / aligned / no-config)
- [x] pre-commit (ruff format, ruff, pyright, pytest) green

Made with [Cursor](https://cursor.com)