### PR TITLE
chore(release): cut 0.1.2

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ergon-framework-python"
-version = "0.1.1"
+version = "0.1.2"
 description = "Ergon internal task-oriented project bootstrapper"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Patch release bumping `ergon-framework-python` to **0.1.2**.

Ships the RabbitMQ consumer recovery fixes merged in #53 (deterministic teardown to kill the zombie consumer + channel leak, fail-fast heartbeat/ack timeouts, prefetch guardrail, and a consumer liveness `health()` surface).

No code changes here beyond the version bump in `sdks/python/pyproject.toml`.

Made with [Cursor](https://cursor.com)