### PR TITLE
chore(release): cut 0.1.3 with Nylas connector updates

### DIFF
--- a/sdks/python/examples/nylas/task_consumer.py
+++ b/sdks/python/examples/nylas/task_consumer.py
@@ -15,7 +15,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from dotenv import load_dotenv
 
@@ -96,7 +96,7 @@ def _build_task_config() -> TaskConfig:
         name="email-processor",
         task=EmailProcessorTask,
         max_workers=1,
-        connectors={    
+        connectors={
             "inbox": ConnectorConfig(
                 connector=AsyncNylasConnector,
                 kwargs={

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ergon-framework-python"
-version = "0.1.2"
+version = "0.1.3"
 description = "Ergon internal task-oriented project bootstrapper"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/src/ergon/__init__.py
+++ b/sdks/python/src/ergon/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "manager",
 ]
 
-__version__ = "0.1.1"
+__version__ = "0.1.3"

--- a/sdks/python/src/ergon/connector/__init__.py
+++ b/sdks/python/src/ergon/connector/__init__.py
@@ -1,5 +1,23 @@
 from .connector import AsyncConnector, Connector, ConnectorConfig
 from .excel import ExcelConnector, ExcelFetchConfig, ExcelRow, ExcelService
+from .nylas import (
+    AckActionConfig,
+    AsyncNylasAuthService,
+    AsyncNylasConnector,
+    AsyncNylasService,
+    AuthUrlConfig,
+    CodeExchangeInput,
+    GrantAuthResult,
+    MessageQueryFilter,
+    NylasAuthClient,
+    NylasAuthService,
+    NylasClient,
+    NylasConnector,
+    NylasConsumerConfig,
+    NylasProducerConfig,
+    NylasService,
+    SendMessageInput,
+)
 from .postgres import (
     AsyncPostgresConnector,
     AsyncPostgresService,
@@ -18,24 +36,6 @@ from .rabbitmq import (
     RabbitmqConsumerMessage,
     RabbitmqProducerMessage,
     RabbitMQService,
-)
-from .nylas import (
-    AckActionConfig,
-    AsyncNylasAuthService,
-    AsyncNylasConnector,
-    AsyncNylasService,
-    AuthUrlConfig,
-    CodeExchangeInput,
-    GrantAuthResult,
-    MessageQueryFilter,
-    NylasAuthClient,
-    NylasAuthService,
-    NylasClient,
-    NylasConnector,
-    NylasConsumerConfig,
-    NylasProducerConfig,
-    NylasService,
-    SendMessageInput,
 )
 from .sqs import (
     AsyncSQSConnector,

--- a/sdks/python/tests/connector/nylas/test_connector.py
+++ b/sdks/python/tests/connector/nylas/test_connector.py
@@ -1,6 +1,6 @@
 """Tests for NylasConnector — fetch/dispatch mapping to Transaction, ack."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/sdks/python/tests/connector/nylas/test_service.py
+++ b/sdks/python/tests/connector/nylas/test_service.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from ergon.connector.nylas.models import MessageQueryFilter, NylasClient
 from ergon.connector.nylas.service import NylasService
 

--- a/sdks/python/tests/connector/nylas/test_utils.py
+++ b/sdks/python/tests/connector/nylas/test_utils.py
@@ -3,10 +3,10 @@
 from ergon.connector.nylas.models import (
     AckActionConfig,
     ClientSideFilter,
+    EmailAddress,
     MessageQueryFilter,
     NylasConsumerConfig,
     SendMessageInput,
-    EmailAddress,
 )
 from ergon.connector.nylas.utils import (
     apply_client_side_filter,

--- a/sdks/python/tests/test_smoke.py
+++ b/sdks/python/tests/test_smoke.py
@@ -4,4 +4,4 @@ import ergon
 
 
 def test_ergon_package_is_importable() -> None:
-    assert ergon.__version__ == "0.1.1"
+    assert ergon.__version__ == "0.1.3"


### PR DESCRIPTION
## Summary
- Bump `ergon-framework-python` release version to `0.1.3` in package metadata and smoke test assertions.
- Align connector exports and Nylas example/test files with the finalized Nylas connector release changes.
- Prepare branch state used for the PyPI deployment of the new version.

## Test plan
- [ ] Run `pytest sdks/python/tests/test_smoke.py`
- [ ] Run `pytest sdks/python/tests/connector/nylas`
- [ ] Validate install of optional dependency with `pip install "ergon-framework-python[nylas]"`