### PR TITLE
chore(release): cut 0.1.5

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ergon-framework-python"
-version = "0.1.3"
+version = "0.1.5"
 description = "Ergon internal task-oriented project bootstrapper"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/src/ergon/__init__.py
+++ b/sdks/python/src/ergon/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "manager",
 ]
 
-__version__ = "0.1.3"
+__version__ = "0.1.5"

--- a/sdks/python/tests/test_smoke.py
+++ b/sdks/python/tests/test_smoke.py
@@ -4,4 +4,4 @@ import ergon
 
 
 def test_ergon_package_is_importable() -> None:
-    assert ergon.__version__ == "0.1.3"
+    assert ergon.__version__ == "0.1.5"


### PR DESCRIPTION
## Summary
- bump package and runtime versions to `0.1.5`
- align the smoke test with the release version
- skip `0.1.4` because that version already exists on PyPI but was never recorded in repository history

## Test plan
- [x] `uv run pytest -q` (322 passed)
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pyright`
- [x] `uv build`
- [x] `uvx twine check dist/*`

Made with [Cursor](https://cursor.com)