### PR TITLE
fix(runner): cleanly terminate async tasks

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ergon-framework-python"
-version = "0.1.5"
+version = "0.1.6"
 description = "Ergon internal task-oriented project bootstrapper"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/src/ergon/__init__.py
+++ b/sdks/python/src/ergon/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "manager",
 ]
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"

--- a/sdks/python/src/ergon/task/runner.py
+++ b/sdks/python/src/ergon/task/runner.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import logging as stdlib_logging
 import os
 import signal
@@ -6,6 +7,7 @@ import threading
 import time
 import traceback
 import uuid
+from collections.abc import Callable
 from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
 from enum import IntEnum
@@ -41,6 +43,8 @@ class ExitCode(IntEnum):
 
 _shutdown_event = threading.Event()
 _shutdown_signal: int | None = None
+_shutdown_callbacks: set[Callable[[], None]] = set()
+_shutdown_callbacks_lock = threading.Lock()
 _supervisor_logger = stdlib_logging.getLogger(__name__)
 
 
@@ -48,11 +52,39 @@ def _signal_handler(signum, frame):
     global _shutdown_signal
     _shutdown_signal = signum
     _shutdown_event.set()
+    with _shutdown_callbacks_lock:
+        callbacks = tuple(_shutdown_callbacks)
+    for callback in callbacks:
+        try:
+            callback()
+        except Exception:
+            _supervisor_logger.exception("Async shutdown callback failed")
 
 
 def _install_signal_handlers():
     signal.signal(signal.SIGINT, _signal_handler)
     signal.signal(signal.SIGTERM, _signal_handler)
+
+
+def _reset_shutdown_state() -> None:
+    global _shutdown_signal
+    _shutdown_event.clear()
+    _shutdown_signal = None
+    with _shutdown_callbacks_lock:
+        _shutdown_callbacks.clear()
+
+
+def _register_shutdown_callback(callback: Callable[[], None]) -> None:
+    with _shutdown_callbacks_lock:
+        _shutdown_callbacks.add(callback)
+        shutdown_requested = _shutdown_event.is_set()
+    if shutdown_requested:
+        callback()
+
+
+def _unregister_shutdown_callback(callback: Callable[[], None]) -> None:
+    with _shutdown_callbacks_lock:
+        _shutdown_callbacks.discard(callback)
 
 
 def is_shutdown_requested() -> bool:
@@ -216,20 +248,31 @@ async def __run_task_async(
 
     instance = None
     supervisor = None
+    liveness_shutdown_requested = threading.Event()
+    connectors: dict[str, Any] = {}
+    services: dict[str, Any] = {}
+    loop = asyncio.get_running_loop()
+    runner_task = asyncio.current_task()
+
+    def request_signal_shutdown() -> None:
+        if runner_task is not None and not runner_task.done():
+            loop.call_soon_threadsafe(runner_task.cancel, "Process shutdown requested")
+
+    _register_shutdown_callback(request_signal_shutdown)
 
     try:
         with tracer.start_as_current_span(  # type: ignore[attr-defined]
             f"{config.task.__name__}.run",
             attributes={"task.execution.id": task_exec_metadata["execution_id"]},
         ):
-            connectors = {}
             for name, cfg in config.connectors.items():
                 conn = cfg.connector(*cfg.args, **cfg.kwargs)
+                connectors[name] = conn
                 if hasattr(conn, "init_async"):
                     await conn.init_async()  # type: ignore[attr-defined]
-                connectors[name] = conn
 
-            services = {name: cfg.service(*cfg.args, **cfg.kwargs) for name, cfg in config.services.items()}
+            for name, cfg in config.services.items():
+                services[name] = cfg.service(*cfg.args, **cfg.kwargs)
 
             instance = config.task(
                 connectors=connectors,
@@ -242,10 +285,9 @@ async def __run_task_async(
             )
 
             if config.supervision.enabled and isinstance(instance, LivenessProvider):
-                loop = asyncio.get_running_loop()
-                runner_task = asyncio.current_task()
 
                 def request_liveness_shutdown(reason: str) -> None:
+                    liveness_shutdown_requested.set()
                     if runner_task is not None and not runner_task.done():
                         loop.call_soon_threadsafe(runner_task.cancel, f"Task unhealthy: {reason}")
 
@@ -266,11 +308,37 @@ async def __run_task_async(
             else:
                 await instance.execute()
 
+    except asyncio.CancelledError:
+        if not is_shutdown_requested():
+            raise
     finally:
-        if supervisor is not None:
+        _unregister_shutdown_callback(request_signal_shutdown)
+        if supervisor is not None and not liveness_shutdown_requested.is_set():
             supervisor.stop()
-        if instance is not None:
-            await instance.exit()
+        try:
+            if instance is not None:
+                await instance.exit()
+        finally:
+            try:
+                resources = [*connectors.values(), *services.values()]
+                for resource in reversed(resources):
+                    close = getattr(resource, "close", None)
+                    if close is None:
+                        close = getattr(resource, "aclose", None)
+                    if not callable(close):
+                        continue
+                    try:
+                        result = close()
+                        if inspect.isawaitable(result):
+                            await result
+                    except Exception:
+                        _supervisor_logger.exception(
+                            "Failed to close async task resource %s",
+                            type(resource).__name__,
+                        )
+            finally:
+                if supervisor is not None:
+                    supervisor.stop()
 
 
 # =============================================================
@@ -424,6 +492,7 @@ def run_task(
     Returns POSIX-compatible exit code.
     """
 
+    _reset_shutdown_state()
     _install_signal_handlers()
     is_async = issubclass(config.task, BaseAsyncTask)  # type: ignore[arg-type]
 

--- a/sdks/python/tests/task/test_runner_lifecycle.py
+++ b/sdks/python/tests/task/test_runner_lifecycle.py
@@ -1,0 +1,160 @@
+import asyncio
+import signal
+
+import pytest
+
+from ergon.connector import AsyncConnector, ConnectorConfig
+from ergon.service import ServiceConfig
+from ergon.task import runner
+from ergon.task.base import BaseAsyncTask, TaskConfig
+
+
+class _AsyncTestConnector(AsyncConnector):
+    async def fetch_transactions_async(self, *args, **kwargs):
+        return []
+
+    async def dispatch_transactions_async(self, transactions, *args, **kwargs):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def reset_shutdown_state():
+    runner._reset_shutdown_state()
+    yield
+    runner._reset_shutdown_state()
+
+
+def test_run_task_returns_signal_exit_code(monkeypatch):
+    class Task(BaseAsyncTask):
+        async def execute(self):
+            runner._signal_handler(signal.SIGTERM, None)
+            await asyncio.sleep(0)
+
+    monkeypatch.setattr(runner, "_install_signal_handlers", lambda: None)
+
+    config = TaskConfig(
+        name="signal-exit-code",
+        task=Task,
+        connectors={"test": ConnectorConfig(connector=_AsyncTestConnector)},
+    )
+
+    assert runner.run_task(config) == 143
+
+
+@pytest.mark.asyncio
+async def test_signal_cancels_async_execution_and_runs_cleanup():
+    started = asyncio.Event()
+    state = {
+        "cancelled": False,
+        "task_exited": False,
+        "connector_closed": False,
+    }
+
+    class Connector(_AsyncTestConnector):
+        async def init_async(self):
+            return None
+
+        async def close(self):
+            state["connector_closed"] = True
+
+    class Task(BaseAsyncTask):
+        async def execute(self):
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                state["cancelled"] = True
+                raise
+
+        async def exit(self):
+            state["task_exited"] = True
+
+    config = TaskConfig(
+        name="signal-lifecycle",
+        task=Task,
+        connectors={"test": ConnectorConfig(connector=Connector)},
+    )
+
+    execution = asyncio.create_task(runner.__run_task_async(config, "task"))
+    await asyncio.wait_for(started.wait(), timeout=1)
+    runner._signal_handler(signal.SIGTERM, None)
+    await asyncio.wait_for(execution, timeout=1)
+
+    assert state == {
+        "cancelled": True,
+        "task_exited": True,
+        "connector_closed": True,
+    }
+    assert runner.get_shutdown_exit_code() == runner.ExitCode.SIGTERM
+
+
+@pytest.mark.asyncio
+async def test_resources_close_in_reverse_initialization_order():
+    events: list[str] = []
+
+    class Connector(_AsyncTestConnector):
+        async def init_async(self):
+            events.append("connector.init")
+
+        async def close(self):
+            events.append("connector.close")
+
+    class Service:
+        def __init__(self):
+            events.append("service.init")
+
+        async def close(self):
+            events.append("service.close")
+
+    class Task(BaseAsyncTask):
+        async def execute(self):
+            events.append("task.execute")
+
+        async def exit(self):
+            events.append("task.exit")
+
+    config = TaskConfig(
+        name="resource-lifecycle",
+        task=Task,
+        connectors={"test": ConnectorConfig(connector=Connector)},
+        services={"test": ServiceConfig(service=Service)},
+    )
+
+    await runner.__run_task_async(config, "task")
+
+    assert events == [
+        "connector.init",
+        "service.init",
+        "task.execute",
+        "task.exit",
+        "service.close",
+        "connector.close",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_partially_initialized_connector_closes_after_init_failure():
+    closed = False
+
+    class Connector(_AsyncTestConnector):
+        async def init_async(self):
+            raise RuntimeError("init failed")
+
+        async def close(self):
+            nonlocal closed
+            closed = True
+
+    class Task(BaseAsyncTask):
+        async def execute(self):
+            raise AssertionError("task should not be constructed")
+
+    config = TaskConfig(
+        name="partial-init",
+        task=Task,
+        connectors={"test": ConnectorConfig(connector=Connector)},
+    )
+
+    with pytest.raises(RuntimeError, match="init failed"):
+        await runner.__run_task_async(config, "task")
+
+    assert closed is True

--- a/sdks/python/tests/test_smoke.py
+++ b/sdks/python/tests/test_smoke.py
@@ -4,4 +4,4 @@ import ergon
 
 
 def test_ergon_package_is_importable() -> None:
-    assert ergon.__version__ == "0.1.5"
+    assert ergon.__version__ == "0.1.6"


### PR DESCRIPTION
## Summary
- cancel active async task execution when SIGINT/SIGTERM is received and preserve POSIX signal exit codes
- close initialized services and connectors in reverse order, including partial startup failures
- keep liveness hard-exit supervision active through cleanup and cut framework version 0.1.6

## Test plan
- [x] `uv run pytest -q` (326 passed)
- [x] `uv run pyright`
- [x] `uv run ruff check src/ergon/task/runner.py tests/task/test_runner_lifecycle.py`
- [x] `uv build`

Made with [Cursor](https://cursor.com)