### PR TITLE
fix(rabbitmq): recover consumers without batching latency

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ergon-framework-python"
-version = "0.1.6"
+version = "0.1.7"
 description = "Ergon internal task-oriented project bootstrapper"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/src/ergon/__init__.py
+++ b/sdks/python/src/ergon/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "manager",
 ]
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/sdks/python/src/ergon/connector/rabbitmq/async_service.py
+++ b/sdks/python/src/ergon/connector/rabbitmq/async_service.py
@@ -4,7 +4,6 @@ import logging
 import ssl as ssl_module
 import time
 from collections import deque
-from contextlib import AsyncExitStack
 from typing import Any, AsyncContextManager, Callable, Dict, List, Optional, cast
 
 import aio_pika
@@ -24,15 +23,36 @@ from .models import AsyncRabbitmqClient, AsyncRabbitmqConsumerConfig, AsyncRabbi
 logger = logging.getLogger(__name__)
 
 
-# Exception classes that signal the underlying channel is no longer usable.
-# We catch these on ack/nack and surface a typed DeadChannelError so the
-# consumer mixin can short-circuit cleanly instead of cascading further
-# failures (nack on the same dead channel).
-_DEAD_CHANNEL_EXCEPTIONS: tuple[type[BaseException], ...] = (
-    aio_pika.exceptions.MessageProcessError,
-    aio_pika.exceptions.ChannelClosed,
+# Invalid channel state always means the active transport disappeared. Broader
+# AMQP connection hierarchies also contain permanent authentication/protocol
+# errors, so consume-time recovery uses the classifier below instead.
+_CHANNEL_INVALID_EXCEPTIONS: tuple[type[BaseException], ...] = (
     aio_pika.exceptions.ChannelInvalidStateError,
     aiormq.exceptions.ChannelInvalidStateError,
+)
+
+
+def _is_recoverable_broker_interruption(exc: BaseException) -> bool:
+    if isinstance(exc, _CHANNEL_INVALID_EXCEPTIONS):
+        return True
+    if type(exc) is aiormq.exceptions.AMQPConnectionError:
+        return True
+    if type(exc) is aiormq.exceptions.ConnectionClosed:
+        reply_code = exc.args[0] if exc.args else None
+        return reply_code == 320
+    if type(exc) is aiormq.exceptions.ConnectionInternalError:
+        return True
+    return False
+
+
+# Settlement can additionally discover a channel-level failure after delivery.
+# Surface those as DeadChannelError so the consumer mixin does not attempt a
+# second settlement on the same unusable channel.
+_DEAD_CHANNEL_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    aio_pika.exceptions.AMQPConnectionError,
+    *_CHANNEL_INVALID_EXCEPTIONS,
+    aio_pika.exceptions.MessageProcessError,
+    aio_pika.exceptions.ChannelClosed,
 )
 
 # Same as above plus ``TimeoutError`` (raised by the async timeout context when an
@@ -193,7 +213,8 @@ class AsyncRabbitMQService:
             return
         try:
             if not channel.is_closed:
-                await channel.close()
+                async with timeout_after(min(1.0, self.client.channel_timeout)):
+                    await channel.close()
                 logger.info("Closed dead consume channel (%s)", reason)
         except Exception as exc:  # noqa: BLE001 - best-effort teardown
             logger.warning("Error closing consume channel during teardown (%s): %r", reason, exc)
@@ -365,27 +386,33 @@ class AsyncRabbitMQService:
         self._consumer_state = "subscribing"
         poll_completed = False
 
-        # Ensure the consume channel exists with the requested prefetch QoS.
-        # The return value is unused here because declare_exchange/declare_queue
-        # re-fetch the channel from the cache.
-        await self._get_consume_channel(prefetch_count=config.prefetch_count)
+        try:
+            # Ensure the consume channel exists with the requested prefetch QoS.
+            # The return value is unused here because declarations re-fetch the
+            # channel from the cache.
+            await self._get_consume_channel(prefetch_count=config.prefetch_count)
 
-        queues: list[tuple[str, AbstractQueue]] = []
-        for subscription in config.resolved_subscriptions():
-            queue = await self.declare_queue(
-                subscription.queue_name,
-                durable=config.durable,
-                arguments=subscription.queue_arguments or None,
-            )
-            for binding in subscription.bindings:
-                exchange = await self.declare_exchange(
-                    binding.exchange_name,
-                    binding.exchange_type,
+            queues: list[tuple[str, AbstractQueue]] = []
+            for subscription in config.resolved_subscriptions():
+                queue = await self.declare_queue(
+                    subscription.queue_name,
                     durable=config.durable,
+                    arguments=subscription.queue_arguments or None,
                 )
-                for key in binding.routing_keys:
-                    await self.bind_queue(queue, exchange, key)
-            queues.append((subscription.queue_name, queue))
+                for binding in subscription.bindings:
+                    exchange = await self.declare_exchange(
+                        binding.exchange_name,
+                        binding.exchange_type,
+                        durable=config.durable,
+                    )
+                    for key in binding.routing_keys:
+                        await self.bind_queue(queue, exchange, key)
+                queues.append((subscription.queue_name, queue))
+        except Exception as exc:
+            if not _is_recoverable_broker_interruption(exc):
+                raise
+            await self._teardown_consume_channel(f"subscription setup interrupted: {exc!r}")
+            return []
 
         buffer: List[Dict[str, Any]] = []
         timeout = config.consume_timeout
@@ -404,7 +431,9 @@ class AsyncRabbitMQService:
                     )
         except TimeoutError:
             poll_completed = True
-        except _DEAD_CHANNEL_EXCEPTIONS as exc:
+        except Exception as exc:
+            if not _is_recoverable_broker_interruption(exc):
+                raise
             # Broker cancelled this subscription mid-iteration; deterministically
             # tear down (cancel consumers + close) the dead channel so the next
             # call rebuilds against a fresh consumer, the broker redelivers what
@@ -435,15 +464,27 @@ class AsyncRabbitMQService:
         batch_size: int,
         auto_ack: bool,
     ) -> None:
-        """Merge deliveries from multiple queue iterators into one batch."""
+        """Wait for one delivery, then drain only messages already available.
+
+        ``consume_timeout`` bounds the idle wait in :meth:`consume`; it must
+        not become a batch-assembly delay after the first delivery. Once any
+        message is buffered, give newly scheduled iterator reads one event-loop
+        turn to complete and return immediately if none are ready.
+        """
         pending: dict[asyncio.Task, tuple[str, Any]] = {}
-        async with AsyncExitStack() as stack:
+        iterator_contexts: list[AsyncContextManager[Any]] = []
+        try:
             for queue_name, queue in queues:
                 iterator_context = cast(
                     AsyncContextManager[Any],
-                    queue.iterator(no_ack=auto_ack),
+                    # The framework owns consumer teardown/resubscription.
+                    # Letting aio-pika restore these short-lived per-fetch
+                    # consumers can resurrect an iterator with no pending
+                    # reader after a broker restart, creating a zombie tag.
+                    queue.iterator(no_ack=auto_ack, robust=False),
                 )
-                iterator = await stack.enter_async_context(iterator_context)
+                iterator = await iterator_context.__aenter__()
+                iterator_contexts.append(iterator_context)
                 self._register_consumer_cancel_callback(iterator)
                 consumer_tag = getattr(iterator, "_consumer_tag", None) or getattr(iterator, "consumer_tag", None)
                 if consumer_tag:
@@ -451,33 +492,68 @@ class AsyncRabbitMQService:
                 pending[asyncio.create_task(anext(iterator))] = (queue_name, iterator)
 
             self._active_consumer_tag = next(iter(self._active_consumer_tags.values()), None)
+            while pending and len(buffer) < batch_size:
+                if buffer:
+                    done = {task for task in pending if task.done()}
+                    if not done:
+                        await asyncio.sleep(0)
+                        done = {task for task in pending if task.done()}
+                    if not done:
+                        break
+                else:
+                    done, _ = await asyncio.wait(
+                        pending,
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                for task in done:
+                    queue_name, iterator = pending.pop(task)
+                    try:
+                        message = task.result()
+                    except StopAsyncIteration:
+                        self._active_consumer_tags.pop(queue_name, None)
+                        continue
 
+                    message_dict = self._message_to_dict(message, queue_name=queue_name)
+                    self._in_flight_message_ids.add(id(message))
+                    self._last_fetch_ts = time.time()
+                    self._consumer_state = "delivering"
+                    if len(buffer) < batch_size:
+                        buffer.append(message_dict)
+                    else:
+                        self._prefetched_messages.append(message_dict)
+                    if len(buffer) < batch_size:
+                        pending[asyncio.create_task(anext(iterator))] = (queue_name, iterator)
+        finally:
+            cleanup_timeout = min(1.0, self.client.channel_timeout)
+            cleanup_failed = False
+            for task in pending:
+                task.cancel()
+            if pending:
+                try:
+                    async with timeout_after(cleanup_timeout):
+                        await asyncio.gather(*pending, return_exceptions=True)
+                except TimeoutError:
+                    cleanup_failed = True
+                    logger.warning("Timed out cancelling RabbitMQ iterator reads")
+            cleanup_failed = await self._close_iterator_contexts(iterator_contexts) or cleanup_failed
+            if cleanup_failed:
+                await self._teardown_consume_channel("queue iterator cleanup failed")
+
+    async def _close_iterator_contexts(
+        self,
+        iterator_contexts: list[AsyncContextManager[Any]],
+    ) -> bool:
+        """Bound queue-iterator cleanup so a dead broker cannot stall a poll."""
+        cleanup_timeout = min(1.0, self.client.channel_timeout)
+        cleanup_failed = False
+        for iterator_context in reversed(iterator_contexts):
             try:
-                while pending and len(buffer) < batch_size:
-                    done, _ = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
-                    for task in done:
-                        queue_name, iterator = pending.pop(task)
-                        try:
-                            message = task.result()
-                        except StopAsyncIteration:
-                            self._active_consumer_tags.pop(queue_name, None)
-                            continue
-
-                        message_dict = self._message_to_dict(message, queue_name=queue_name)
-                        self._in_flight_message_ids.add(id(message))
-                        self._last_fetch_ts = time.time()
-                        self._consumer_state = "delivering"
-                        if len(buffer) < batch_size:
-                            buffer.append(message_dict)
-                        else:
-                            self._prefetched_messages.append(message_dict)
-                        if len(buffer) < batch_size:
-                            pending[asyncio.create_task(anext(iterator))] = (queue_name, iterator)
-            finally:
-                for task in pending:
-                    task.cancel()
-                if pending:
-                    await asyncio.gather(*pending, return_exceptions=True)
+                async with timeout_after(cleanup_timeout):
+                    await iterator_context.__aexit__(None, None, None)
+            except Exception as exc:
+                cleanup_failed = True
+                logger.warning("RabbitMQ queue iterator cleanup failed: %r", exc)
+        return cleanup_failed
 
     def _register_consumer_cancel_callback(self, iterator: Any) -> None:
         """Best-effort registration of an on-cancel callback on the iterator's consumer.

--- a/sdks/python/tests/connector/rabbitmq/test_async_service.py
+++ b/sdks/python/tests/connector/rabbitmq/test_async_service.py
@@ -1,16 +1,21 @@
 """Tests for AsyncRabbitMQService — connection lifecycle, consume, publish, ack/nack."""
 
 import asyncio
+import builtins
 import json
 import time
 from contextlib import asynccontextmanager
+from typing import Any, AsyncContextManager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aio_pika.exceptions
 import aiormq.exceptions
 import pytest
 
-from ergon.connector.rabbitmq.async_service import AsyncRabbitMQService
+from ergon.connector.rabbitmq.async_service import (
+    AsyncRabbitMQService,
+    _is_recoverable_broker_interruption,
+)
 from ergon.connector.rabbitmq.models import (
     AsyncRabbitmqClient,
     AsyncRabbitmqConsumerConfig,
@@ -25,8 +30,12 @@ from ergon.task.exceptions import (
 )
 
 
-def _make_client(**overrides) -> AsyncRabbitmqClient:
-    defaults = {"username": "guest", "password": "guest", "host": "localhost"}
+def _make_client(**overrides: Any) -> AsyncRabbitmqClient:
+    defaults: dict[str, Any] = {
+        "username": "guest",
+        "password": "guest",
+        "host": "localhost",
+    }
     defaults.update(overrides)
     return AsyncRabbitmqClient(**defaults)
 
@@ -162,6 +171,14 @@ class TestConnection:
 
 
 class TestConsume:
+    def test_internal_connection_error_is_recoverable(self):
+        exc = aiormq.exceptions.ConnectionInternalError(
+            541,
+            "broker internal error",
+        )
+
+        assert _is_recoverable_broker_interruption(exc) is True
+
     def test_legacy_config_resolves_to_one_subscription(self):
         config = AsyncRabbitmqConsumerConfig(
             queue_name="test-queue",
@@ -186,9 +203,12 @@ class TestConsume:
     @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
     async def test_consume_returns_messages(self, mock_connect):
         msg = _mock_message()
+        iterator_kwargs: dict[str, Any] = {}
 
         @asynccontextmanager
         async def _iterator_cm(**kwargs):
+            iterator_kwargs.update(kwargs)
+
             async def _gen():
                 yield msg
 
@@ -225,6 +245,76 @@ class TestConsume:
         assert result[0]["body"] == {"key": "val"}
         assert result[0]["routing_key"] == "test.key"
         assert result[0]["delivery_tag"] == 1
+        assert iterator_kwargs == {"no_ack": False, "robust": False}
+
+    @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
+    async def test_consume_returns_first_delivery_without_waiting_to_fill_batch(self, mock_connect):
+        first_message = _mock_message(delivery_tag=1)
+        second_message = _mock_message(delivery_tag=2)
+        release_second = asyncio.Event()
+
+        @asynccontextmanager
+        async def _iterator_cm(**kwargs):
+            async def _gen():
+                yield first_message
+                await release_second.wait()
+                yield second_message
+
+            yield _gen()
+
+        mock_queue = MagicMock()
+        mock_queue.iterator = _iterator_cm
+
+        mock_channel = _mock_channel()
+        mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
+
+        mock_conn = AsyncMock()
+        mock_conn.is_closed = False
+        mock_conn.channel = AsyncMock(return_value=mock_channel)
+        mock_connect.return_value = mock_conn
+
+        service = AsyncRabbitMQService(_make_client())
+        config = AsyncRabbitmqConsumerConfig(
+            queue_name="test-queue",
+            consume_timeout=10,
+        )
+
+        result = await asyncio.wait_for(service.consume(config, batch_size=10), timeout=0.5)
+
+        assert [message["delivery_tag"] for message in result] == [1]
+
+    @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
+    async def test_consume_nonblocking_drains_immediately_available_messages(self, mock_connect):
+        messages = [_mock_message(delivery_tag=index) for index in range(1, 4)]
+
+        @asynccontextmanager
+        async def _iterator_cm(**kwargs):
+            async def _gen():
+                for message in messages:
+                    yield message
+
+            yield _gen()
+
+        mock_queue = MagicMock()
+        mock_queue.iterator = _iterator_cm
+
+        mock_channel = _mock_channel()
+        mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
+
+        mock_conn = AsyncMock()
+        mock_conn.is_closed = False
+        mock_conn.channel = AsyncMock(return_value=mock_channel)
+        mock_connect.return_value = mock_conn
+
+        service = AsyncRabbitMQService(_make_client())
+        config = AsyncRabbitmqConsumerConfig(
+            queue_name="test-queue",
+            consume_timeout=10,
+        )
+
+        result = await asyncio.wait_for(service.consume(config, batch_size=10), timeout=0.5)
+
+        assert [message["delivery_tag"] for message in result] == [1, 2, 3]
 
     @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
     async def test_consume_merges_multiple_queue_subscriptions(self, mock_connect):
@@ -493,6 +583,191 @@ class TestConsume:
         assert health["last_poll_started_ts"] is not None
         assert health["last_poll_completed_ts"] is not None
         assert health["in_flight_count"] == 0
+
+    @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
+    async def test_consume_recovers_when_connection_closes_during_subscription_setup(
+        self,
+        mock_connect,
+    ):
+        mock_channel = _mock_channel()
+        mock_channel.declare_queue = AsyncMock(side_effect=aiormq.exceptions.ConnectionClosed(320, "broker shutdown"))
+
+        mock_conn = AsyncMock()
+        mock_conn.is_closed = False
+        mock_conn.channel = AsyncMock(return_value=mock_channel)
+        mock_connect.return_value = mock_conn
+
+        service = AsyncRabbitMQService(_make_client())
+        config = AsyncRabbitmqConsumerConfig(queue_name="test-queue")
+
+        result = await service.consume(config, batch_size=10)
+
+        assert result == []
+        mock_channel.close.assert_awaited_once()
+        assert service.health()["consumer_epoch"] == 1
+
+    @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
+    async def test_consume_propagates_permanent_topology_errors(self, mock_connect):
+        mock_channel = _mock_channel()
+        mock_channel.declare_queue = AsyncMock(
+            side_effect=aiormq.exceptions.ChannelPreconditionFailed(
+                406,
+                "inequivalent queue arguments",
+            )
+        )
+
+        mock_conn = AsyncMock()
+        mock_conn.is_closed = False
+        mock_conn.channel = AsyncMock(return_value=mock_channel)
+        mock_connect.return_value = mock_conn
+
+        service = AsyncRabbitMQService(_make_client())
+        config = AsyncRabbitmqConsumerConfig(queue_name="test-queue")
+
+        with pytest.raises(
+            aiormq.exceptions.ChannelPreconditionFailed,
+            match="inequivalent queue arguments",
+        ):
+            await service.consume(config, batch_size=10)
+
+    @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
+    async def test_consume_propagates_permanent_authentication_errors(self, mock_connect):
+        mock_channel = _mock_channel()
+        mock_channel.declare_queue = AsyncMock(side_effect=aiormq.exceptions.AuthenticationError("invalid credentials"))
+
+        mock_conn = AsyncMock()
+        mock_conn.is_closed = False
+        mock_conn.channel = AsyncMock(return_value=mock_channel)
+        mock_connect.return_value = mock_conn
+
+        service = AsyncRabbitMQService(_make_client())
+        config = AsyncRabbitmqConsumerConfig(queue_name="test-queue")
+
+        with pytest.raises(
+            aiormq.exceptions.AuthenticationError,
+            match="invalid credentials",
+        ):
+            await service.consume(config, batch_size=10)
+
+    @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
+    async def test_consume_bounds_iterator_cleanup_when_broker_is_unresponsive(self, mock_connect):
+        class HangingIteratorContext:
+            async def __aenter__(self):
+                async def _gen():
+                    await asyncio.sleep(10)
+                    return
+                    yield
+
+                return _gen()
+
+            async def __aexit__(self, exc_type, exc, traceback):
+                await asyncio.sleep(10)
+
+        mock_queue = MagicMock()
+        mock_queue.name = "test-queue"
+        mock_queue.iterator.return_value = HangingIteratorContext()
+
+        mock_channel = _mock_channel()
+        mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
+
+        mock_conn = AsyncMock()
+        mock_conn.is_closed = False
+        mock_conn.channel = AsyncMock(return_value=mock_channel)
+        mock_connect.return_value = mock_conn
+
+        service = AsyncRabbitMQService(_make_client(channel_timeout=0.1))
+        config = AsyncRabbitmqConsumerConfig(
+            queue_name="test-queue",
+            consume_timeout=0.05,
+        )
+
+        started = time.monotonic()
+        result = await asyncio.wait_for(service.consume(config, batch_size=10), timeout=0.5)
+
+        assert result == []
+        assert time.monotonic() - started < 0.5
+        mock_channel.close.assert_awaited_once()
+        assert service.health()["consumer_epoch"] == 1
+
+    @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
+    async def test_consume_bounds_pending_iterator_cancellation(self, mock_connect):
+        class StubbornIterator:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                try:
+                    await asyncio.sleep(10)
+                except asyncio.CancelledError:
+                    await asyncio.sleep(10)
+                raise StopAsyncIteration
+
+        class IteratorContext:
+            async def __aenter__(self):
+                return StubbornIterator()
+
+            async def __aexit__(self, exc_type, exc, traceback):
+                return None
+
+        mock_queue = MagicMock()
+        mock_queue.name = "test-queue"
+        mock_queue.iterator.return_value = IteratorContext()
+
+        mock_channel = _mock_channel()
+        mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
+
+        mock_conn = AsyncMock()
+        mock_conn.is_closed = False
+        mock_conn.channel = AsyncMock(return_value=mock_channel)
+        mock_connect.return_value = mock_conn
+
+        service = AsyncRabbitMQService(_make_client(channel_timeout=0.1))
+        config = AsyncRabbitmqConsumerConfig(
+            queue_name="test-queue",
+            consume_timeout=0.05,
+        )
+
+        started = time.monotonic()
+        result = await asyncio.wait_for(service.consume(config, batch_size=10), timeout=0.5)
+
+        assert result == []
+        assert time.monotonic() - started < 0.5
+        mock_channel.close.assert_awaited_once()
+        assert service.health()["consumer_epoch"] == 1
+
+    async def test_iterator_cleanup_continues_after_exception_group(self):
+        exception_group_type = getattr(builtins, "ExceptionGroup", None)
+        if exception_group_type is None:
+            pytest.skip("ExceptionGroup requires Python 3.11+")
+
+        closed: list[str] = []
+
+        class IteratorContext:
+            def __init__(self, name: str, *, fail: bool = False):
+                self.name = name
+                self.fail = fail
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, traceback):
+                closed.append(self.name)
+                if self.fail:
+                    raise exception_group_type(
+                        "buffered message cleanup failed",
+                        [RuntimeError("nack failed")],
+                    )
+
+        service = AsyncRabbitMQService(_make_client())
+        contexts: list[AsyncContextManager[Any]] = [
+            IteratorContext("remaining"),
+            IteratorContext("failing", fail=True),
+        ]
+
+        cleanup_failed = await service._close_iterator_contexts(contexts)
+
+        assert cleanup_failed is True
+        assert closed == ["failing", "remaining"]
 
 
 class TestPublish:

--- a/sdks/python/tests/test_smoke.py
+++ b/sdks/python/tests/test_smoke.py
@@ -4,4 +4,4 @@ import ergon
 
 
 def test_ergon_package_is_importable() -> None:
-    assert ergon.__version__ == "0.1.6"
+    assert ergon.__version__ == "0.1.7"


### PR DESCRIPTION
## Summary
- return the first RabbitMQ delivery immediately while non-blockingly draining already available messages into the configured batch
- keep per-fetch consumers framework-owned so aio-pika cannot restore zombie iterator tags after a broker restart
- bound iterator cancellation, context cleanup, and dead-channel close operations
- recover only genuine transport interruptions while propagating permanent authentication and topology errors
- release the corrected behavior as `ergon-framework-python` 0.1.7

## Test plan
- [x] Full framework suite: 335 tests
- [x] Ruff format and lint checks
- [x] Pyright: 0 errors
- [x] Built and smoke-tested the 0.1.7 wheel
- [x] Used the local framework checkout from the platform service environment
- [x] Real isolated RabbitMQ: single delivery after 7 seconds idle (~75 ms)
- [x] Real isolated RabbitMQ: 20-message burst with 19-way observed concurrency
- [x] Real isolated RabbitMQ: two subscriptions recover after broker restart (~11.7 s), then deliver from both queues
- [x] Verified permanent authentication/topology failures are not treated as empty polls

Made with [Cursor](https://cursor.com)