### PR TITLE
fix(rabbitmq): guarantee exit after reconnect timeout

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ergon-framework-python"
-version = "0.1.7"
+version = "0.1.8"
 description = "Ergon internal task-oriented project bootstrapper"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
     "pyright>=1.1.390",
     "pytest>=8.0.0",
     "pytest-asyncio>=0.25.0",
-    "ruff>=0.6.0",
+    "ruff>=0.6.0,<0.16",
 ]
 
 [build-system]

--- a/sdks/python/src/ergon/__init__.py
+++ b/sdks/python/src/ergon/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "manager",
 ]
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"

--- a/sdks/python/src/ergon/connector/rabbitmq/async_service.py
+++ b/sdks/python/src/ergon/connector/rabbitmq/async_service.py
@@ -155,11 +155,33 @@ class AsyncRabbitMQService:
 
         connection = self._connection
         self._connection = None
-        if connection is not None and not connection.is_closed:
-            try:
+        await self._close_connection_safely(connection, reason)
+
+    async def _close_connection_safely(
+        self,
+        connection: Optional[AbstractRobustConnection],
+        reason: str,
+    ) -> None:
+        """Stop transport and robust-reconnect ownership within a fixed deadline.
+
+        ``RobustConnection.is_closed`` only describes its current transport. Its
+        background reconnection task can still be alive after the broker closes
+        that transport, so ``close()`` must always run for an owned connection.
+        """
+        if connection is None:
+            return
+        close_timeout = min(5.0, self.client.connect_timeout)
+        try:
+            async with timeout_after(close_timeout):
                 await connection.close()
-            except Exception as exc:  # noqa: BLE001 - best-effort reset
-                logger.warning("Error closing RabbitMQ connection during reset (%s): %r", reason, exc)
+        except TimeoutError:
+            logger.error(
+                "Timed out closing RabbitMQ connection after %.1fs (%s)",
+                close_timeout,
+                reason,
+            )
+        except Exception as exc:  # noqa: BLE001 - best-effort reset
+            logger.warning("Error closing RabbitMQ connection (%s): %r", reason, exc)
 
     def _invalidate_consume_channel(self, reason: str = "explicit invalidation") -> None:
         """Drop cached consume channel + queue/exchange handles.
@@ -752,9 +774,9 @@ class AsyncRabbitMQService:
                     logger.warning("Error closing %s: %r", attr_name, exc)
             setattr(self, attr_name, None)
 
-        if self._connection is not None and not self._connection.is_closed:
-            await self._connection.close()
-            self._connection = None
+        connection = self._connection
+        self._connection = None
+        await self._close_connection_safely(connection, "service close")
 
         self._active_consumer_tag = None
         self._active_consumer_tags.clear()

--- a/sdks/python/src/ergon/task/runner.py
+++ b/sdks/python/src/ergon/task/runner.py
@@ -106,15 +106,18 @@ class _TaskLivenessSupervisor:
         self,
         provider: LivenessProvider,
         policy: TaskSupervisionPolicy,
-        request_shutdown,
-        hard_exit=os._exit,
+        request_shutdown: Callable[[str], None],
+        hard_exit: Callable[[int], None] | None = None,
     ) -> None:
         self.provider = provider
         self.policy = policy
         self.request_shutdown = request_shutdown
-        self.hard_exit = hard_exit
+        self.hard_exit = hard_exit or os._exit
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
+        self._shutdown_lock = threading.Lock()
+        self._shutdown_requested_at: float | None = None
+        self._shutdown_reason: str | None = None
 
     def start(self) -> None:
         self._thread = threading.Thread(
@@ -129,13 +132,39 @@ class _TaskLivenessSupervisor:
         if self._thread is not None and self._thread is not threading.current_thread():
             self._thread.join(timeout=max(1.0, self.policy.check_interval * 2))
 
+    def arm_shutdown_deadline(self, reason: str) -> None:
+        """Force process exit if any cooperative shutdown or cleanup wedges."""
+        with self._shutdown_lock:
+            if self._shutdown_requested_at is not None:
+                return
+            self._shutdown_requested_at = time.monotonic()
+            self._shutdown_reason = reason
+        _supervisor_logger.warning(
+            "Task shutdown deadline armed for %.1fs (%s)",
+            self.policy.shutdown_grace,
+            reason,
+        )
+
     def _run(self) -> None:
         started_at = time.monotonic()
         unhealthy_since: float | None = None
-        shutdown_requested_at: float | None = None
 
         while not self._stop.wait(self.policy.check_interval):
             now = time.monotonic()
+            with self._shutdown_lock:
+                shutdown_requested_at = self._shutdown_requested_at
+                shutdown_reason = self._shutdown_reason
+            if shutdown_requested_at is not None:
+                if now - shutdown_requested_at >= self.policy.shutdown_grace:
+                    _supervisor_logger.critical(
+                        "Task did not stop within %.1fs after shutdown began (%s); forcing exit",
+                        self.policy.shutdown_grace,
+                        shutdown_reason,
+                    )
+                    self._stop.set()
+                    self.hard_exit(int(ExitCode.ERROR))
+                continue
+
             if now - started_at < self.policy.startup_grace:
                 continue
 
@@ -157,22 +186,14 @@ class _TaskLivenessSupervisor:
                 _supervisor_logger.error("Task liveness check failed: %s", reason)
                 continue
 
-            if shutdown_requested_at is None and now - unhealthy_since >= self.policy.unhealthy_grace:
-                shutdown_requested_at = now
+            if now - unhealthy_since >= self.policy.unhealthy_grace:
                 _supervisor_logger.critical(
                     "Task remained unhealthy for %.1fs (%s); requesting process shutdown",
                     now - unhealthy_since,
                     reason,
                 )
+                self.arm_shutdown_deadline(reason)
                 self.request_shutdown(reason)
-                continue
-
-            if shutdown_requested_at is not None and now - shutdown_requested_at >= self.policy.shutdown_grace:
-                _supervisor_logger.critical(
-                    "Task did not stop within %.1fs after liveness shutdown request; forcing exit",
-                    self.policy.shutdown_grace,
-                )
-                self.hard_exit(int(ExitCode.ERROR))
 
 
 # =============================================================
@@ -313,8 +334,10 @@ async def __run_task_async(
             raise
     finally:
         _unregister_shutdown_callback(request_signal_shutdown)
-        if supervisor is not None and not liveness_shutdown_requested.is_set():
-            supervisor.stop()
+        if supervisor is not None:
+            supervisor.arm_shutdown_deadline(
+                "liveness shutdown cleanup" if liveness_shutdown_requested.is_set() else "task cleanup"
+            )
         try:
             if instance is not None:
                 await instance.exit()

--- a/sdks/python/tests/connector/rabbitmq/test_async_service.py
+++ b/sdks/python/tests/connector/rabbitmq/test_async_service.py
@@ -112,6 +112,36 @@ class TestConnection:
         assert service._connection is None
         assert service.health()["consumer_epoch"] == 1
 
+    async def test_reset_closes_robust_connection_with_closed_transport(self):
+        mock_conn = AsyncMock()
+        mock_conn.is_closed = True
+        mock_conn.close = AsyncMock()
+
+        service = AsyncRabbitMQService(_make_client())
+        service._connection = mock_conn
+
+        await service._reset_connection("broker shutdown")
+
+        mock_conn.close.assert_awaited_once()
+        assert service._connection is None
+
+    async def test_reset_bounds_robust_connection_close(self):
+        async def never_closes():
+            await asyncio.Event().wait()
+
+        mock_conn = AsyncMock()
+        mock_conn.is_closed = True
+        mock_conn.close = AsyncMock(side_effect=never_closes)
+
+        service = AsyncRabbitMQService(_make_client(connect_timeout=0.02))
+        service._connection = mock_conn
+
+        started = time.monotonic()
+        await asyncio.wait_for(service._reset_connection("network blackhole"), timeout=0.2)
+
+        assert time.monotonic() - started < 0.2
+        assert service._connection is None
+
     async def test_existing_robust_connection_returns_after_recovery(self):
         connected = asyncio.Event()
         mock_conn = AsyncMock()

--- a/sdks/python/tests/task/test_runner_lifecycle.py
+++ b/sdks/python/tests/task/test_runner_lifecycle.py
@@ -1,5 +1,6 @@
 import asyncio
 import signal
+import threading
 
 import pytest
 
@@ -7,6 +8,7 @@ from ergon.connector import AsyncConnector, ConnectorConfig
 from ergon.service import ServiceConfig
 from ergon.task import runner
 from ergon.task.base import BaseAsyncTask, TaskConfig
+from ergon.task.liveness import TaskLivenessSnapshot, TaskSupervisionPolicy
 
 
 class _AsyncTestConnector(AsyncConnector):
@@ -158,3 +160,41 @@ async def test_partially_initialized_connector_closes_after_init_failure():
         await runner.__run_task_async(config, "task")
 
     assert closed is True
+
+
+@pytest.mark.asyncio
+async def test_task_failure_keeps_hard_exit_armed_through_stalled_cleanup(monkeypatch):
+    cleanup_started = asyncio.Event()
+    hard_exit = threading.Event()
+
+    class Task(BaseAsyncTask):
+        def liveness_snapshot(self):
+            return TaskLivenessSnapshot(healthy=True, state="idle")
+
+        async def execute(self):
+            raise RuntimeError("fetch failed")
+
+        async def exit(self):
+            cleanup_started.set()
+            await asyncio.Event().wait()
+
+    monkeypatch.setattr(runner.os, "_exit", lambda _code: hard_exit.set())
+    config = TaskConfig(
+        name="failed-task-cleanup-deadline",
+        task=Task,
+        connectors={"test": ConnectorConfig(connector=_AsyncTestConnector)},
+        supervision=TaskSupervisionPolicy(
+            check_interval=0.01,
+            startup_grace=0,
+            unhealthy_grace=0.01,
+            shutdown_grace=0.02,
+        ),
+    )
+
+    execution = asyncio.create_task(runner.__run_task_async(config, "task"))
+    await asyncio.wait_for(cleanup_started.wait(), timeout=1)
+    assert await asyncio.to_thread(hard_exit.wait, 0.5)
+
+    execution.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await execution

--- a/sdks/python/tests/test_smoke.py
+++ b/sdks/python/tests/test_smoke.py
@@ -4,4 +4,4 @@ import ergon
 
 
 def test_ergon_package_is_importable() -> None:
-    assert ergon.__version__ == "0.1.7"
+    assert ergon.__version__ == "0.1.8"


### PR DESCRIPTION
## Summary
- always close owned robust RabbitMQ connections, even after their transport reports closed, and bound that cleanup
- keep the process hard-exit deadline armed through every supervised task cleanup path so ECS can replace wedged workers
- release the fix as `ergon-framework-python` 0.1.8 with regressions for closed transports, hanging connection cleanup, and ordinary task failures that wedge during teardown

## Test plan
- [x] `uv run pytest -q` (338 passed)
- [x] `uv run pyright`
- [x] `uv run ruff check ...`
- [x] `uv run ruff format --check ...`
- [x] `uv build`
- [x] `uvx twine check dist/*`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)