### PR TITLE
feat(task): add continuous consumer refill

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,6 +143,7 @@ The consumer engine handles all the complexity:
 
 - Fetching batches from connectors
 - Concurrent processing with configurable parallelism
+- Optional continuous refill for long-running async handlers
 - Retry logic with exponential backoff
 - Timeout enforcement
 - Error routing to exception handlers
@@ -275,20 +276,11 @@ ConsumerPolicy {
     name: string
 
     loop {
+        mode: "batch" | "continuous"  // Async scheduling strategy
         concurrency {
             value: int          // Parallel transaction processing
             min: int            // Minimum concurrency
             max: int            // Maximum concurrency
-        }
-        batch {
-            size: int           // Transactions per fetch
-            min_size: int
-            max_size: int
-        }
-        empty_queue {
-            backoff: float              // Initial backoff on empty queue
-            backoff_multiplier: float   // Exponential factor
-            backoff_cap: float          // Maximum backoff
         }
         timeout: int            // Max loop duration (seconds)
         limit: int              // Max transactions to process
@@ -296,6 +288,16 @@ ConsumerPolicy {
     }
 
     fetch {
+        batch {
+            size: int           // Transactions per fetch in batch mode
+            min_size: int
+            max_size: int
+        }
+        empty {
+            backoff: float              // Initial backoff on empty queue
+            backoff_multiplier: float   // Exponential factor
+            backoff_cap: float          // Maximum backoff
+        }
         retry: RetryPolicy
         connector: string       // Connector name to fetch from
     }
@@ -313,6 +315,8 @@ ConsumerPolicy {
     }
 }
 ```
+
+Async consumers use `mode: "batch"` by default: each fetched batch completes before the next fetch. With `mode: "continuous"`, the engine fetches up to the number of free concurrency slots and replaces completed transactions immediately. Continuous mode is intended for broker-backed, I/O-bound workloads whose transaction durations vary significantly; `fetch.batch.size` applies only to batch mode.
 
 Each phase (fetch, process, success, exception) has independent retry configuration. This allows you to, for example, retry business logic 3 times but only retry the exception handler once.
 

--- a/docs/modules/2.task.md
+++ b/docs/modules/2.task.md
@@ -52,7 +52,7 @@ The `ProducerPolicy` controls the execution, including:
 
 ### ConsumerMixin semantics
 
-The Consumer subsystem of the Ergon Framework defines a deterministic, fault-tolerant, and fully observable execution pipeline for any component that consumes and processes transactions. Every transaction is executed inside a strict lifecycle governed by structured retry policies, timeout envelopes, exponential backoff, and automatic OpenTelemetry tracing. The lifecycle is always the same: the engine first attempts to fetch a batch of transactions from the given connector, then processes each transaction independently, and finally routes the outcome into either a success handler or an exception handler.
+The Consumer subsystem of the Ergon Framework defines a deterministic, fault-tolerant, and fully observable execution pipeline for any component that consumes and processes transactions. Every transaction is executed inside a strict lifecycle governed by structured retry policies, timeout envelopes, exponential backoff, and automatic OpenTelemetry tracing. The lifecycle is always the same: the engine fetches transactions from the given connector, processes each transaction independently, and routes the outcome into either a success handler or an exception handler.
 
 #### Lifecycle and Policy Control
 
@@ -62,15 +62,14 @@ The `ConsumerPolicy` defines:
 
 - **Loop Policy (`ConsumerLoopPolicy`)**: Controls the main consumption loop, including:
 
-  - **Batching (`BatchPolicy`)**: Batch size (`size`, `min_size`, `max_size`) and interval.
+  - **Mode**: Async scheduling strategy (`batch` or `continuous`).
   - **Concurrency (`ConcurrencyPolicy`)**: Number of concurrent transactions to process (`value`, `min`, `max`).
-  - **Empty Queue (`EmptyQueuePolicy`)**: Backoff behavior when no transactions are fetched (`backoff`, `backoff_multiplier`, `interval`).
   - **Timeouts**: Loop timeout, transaction processing timeout.
   - **Limits**: Max number of transactions to process.
   - **Streaming**: Boolean flag for streaming mode.
 - **Step Policies**:
 
-  - **Fetch (`FetchPolicy`)**: Controls transaction fetching (retry logic, connector name).
+  - **Fetch (`FetchPolicy`)**: Controls transaction fetching, including batch size and interval, empty-fetch backoff, retry logic, and connector name.
   - **Process (`ProcessPolicy`)**: Controls the `process_transaction` execution (retry logic).
   - **Success (`SuccessPolicy`)**: Controls the `handle_process_success` execution (retry logic).
   - **Exception (`ExceptionPolicy`)**: Controls the `handle_process_exception` execution (retry logic).
@@ -111,6 +110,17 @@ Execution can be synchronous or asynchronous:
 - **Asynchronous**: Uses a semaphore to enforce concurrency limits, enabling highly parallel, high-throughput pipelines without blocking the event loop.
 
 Both models support streaming and non-streaming modes: in streaming mode, empty fetches trigger exponential sleep intervals instead of terminating, allowing the consumer to continuously poll upstream sources without overwhelming them.
+
+#### Async Consumer Loop Modes
+
+`ConsumerLoopPolicy.mode` controls how `AsyncConsumerMixin` fills its bounded concurrency slots:
+
+- **`batch`** (default): Fetches `fetch.batch.size` transactions, processes that finite batch with bounded concurrency, and fetches again only after every transaction in the batch completes. This preserves the behavior of existing policies and is useful when a batch is a meaningful unit of work.
+- **`continuous`**: Fetches up to the number of currently free concurrency slots. As soon as any transaction completes, the loop fetches replacement work without waiting for slower sibling transactions. This avoids head-of-line blocking for broker-backed workloads with long or variable-duration asynchronous handlers.
+
+In continuous mode, `loop.concurrency.value` is both the processing bound and the maximum fetch quantum. `fetch.batch.size` and the batch interval apply only to batch mode. Connector prefetch should normally equal concurrency: a larger prefetch can hold messages unacknowledged without creating additional processing capacity, while a smaller prefetch can leave processing slots idle.
+
+The loop mode is independent of `streaming`. Streaming controls what happens when no work is available: a streaming consumer backs off and polls again, while a non-streaming consumer drains in-flight work and exits. `loop.limit` stops new fetches after the configured number of transactions has been submitted and lets those transactions finish.
 
 In summary, the Consumer Mixin transforms arbitrary transaction handling into a robust processing engine with automatic retries, automatic timeouts, exponential backoff, structured observability, concurrency control, and deterministic failure handling. The design ensures that business logic remains simple while the framework guarantees reliability, stability, and complete traceability across the entire lifecycle of every transaction.
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ergon-framework-python"
-version = "0.1.8"
+version = "0.1.9"
 description = "Ergon internal task-oriented project bootstrapper"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/src/ergon/__init__.py
+++ b/sdks/python/src/ergon/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "manager",
 ]
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/sdks/python/src/ergon/task/mixins/consumer.py
+++ b/sdks/python/src/ergon/task/mixins/consumer.py
@@ -601,22 +601,28 @@ class AsyncConsumerMixin(ABC):
     # =====================================================================
     #   FETCH HANDLER (ASYNC)
     # =====================================================================
-    async def _handle_fetch(self, conn, policy: policies.FetchPolicy) -> tuple[bool, List[connector.Transaction]]:
+    async def _handle_fetch(
+        self,
+        conn,
+        policy: policies.FetchPolicy,
+        batch_size: int | None = None,
+    ) -> tuple[bool, List[connector.Transaction]]:
+        fetch_size = policy.batch.size if batch_size is None else batch_size
         self._mark_consumer_progress("fetching")
-        logger.info(f"Fetch handler started for batch size {policy.batch.size}", extra=policy.extra)
+        logger.info(f"Fetch handler started for batch size {fetch_size}", extra=policy.extra)
         fetch_start = time.perf_counter()
         success, result = await helpers.run_fn_async(
-            fn=lambda: conn.fetch_transactions_async(policy.batch.size, **policy.extra),
+            fn=lambda: conn.fetch_transactions_async(fetch_size, **policy.extra),
             retry=policy.retry,
             trace_name=f"{self.__class__.__name__}.fetch_transactions",
-            trace_attrs={"batch_size": policy.batch.size},
+            trace_attrs={"batch_size": fetch_size},
         )
         # Record fetch metrics
         fetched_count = len(result) if success and result else 0
         mixin_metrics.record_consumer_fetch(
             task_name=getattr(self, "name", self.__class__.__name__),
             connector_name=conn.__class__.__name__,
-            batch_size=policy.batch.size,
+            batch_size=fetch_size,
             fetched_count=fetched_count,
             duration=time.perf_counter() - fetch_start,
             success=success,
@@ -877,13 +883,135 @@ class AsyncConsumerMixin(ABC):
                     )
                     return await self._handle_exception(tr, timeout_error, pol.exception.retry)
 
+            async def _consume_continuous():
+                nonlocal batch_number, empty_count, processed
+
+                concurrency = policy.loop.concurrency.value
+                submitted = 0
+                in_flight: set[asyncio.Task] = set()
+
+                async def reap(done: set[asyncio.Task]) -> None:
+                    nonlocal processed
+                    for task in done:
+                        try:
+                            await task
+                        except Exception as exc:
+                            logger.error("[async] Execution error: %s", exc)
+                        finally:
+                            processed += 1
+
+                async def wait_for_completion() -> None:
+                    done, _ = await asyncio.wait(
+                        in_flight,
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    in_flight.difference_update(done)
+                    await reap(done)
+                    self._mark_consumer_progress("polling")
+
+                try:
+                    while True:
+                        if policy.loop.limit is not None and submitted >= policy.loop.limit:
+                            if in_flight:
+                                await wait_for_completion()
+                                continue
+                            break
+
+                        free_slots = concurrency - len(in_flight)
+                        if free_slots == 0:
+                            await wait_for_completion()
+                            continue
+
+                        if policy.loop.limit is not None:
+                            free_slots = min(free_slots, policy.loop.limit - submitted)
+
+                        logger.debug(
+                            "Fetching transactions for %d free continuous-consumer slot(s) with fetch policy: %s",
+                            free_slots,
+                            policy.fetch.model_dump_json(indent=2),
+                        )
+                        success, result = await self._handle_fetch(
+                            conn,
+                            policy.fetch,
+                            batch_size=free_slots,
+                        )
+
+                        if not success:
+                            logger.error("Fetch failed → %s", result)
+                            if isinstance(result, (asyncio.TimeoutError, futures.TimeoutError)):
+                                raise exceptions.FetchTimeoutException(str(result))
+                            raise exceptions.FetchException(str(result))
+
+                        transactions = result
+                        if transactions:
+                            empty_count = 0
+                            batch_number += 1
+                            self._mark_consumer_progress("processing")
+                            logger.info(
+                                "%d transaction(s) fetched for continuous processing",
+                                len(transactions),
+                            )
+                            mixin_metrics.record_consumer_batch(
+                                task_name=getattr(self, "name", self.__class__.__name__),
+                                batch_number=batch_number,
+                                batch_size=len(transactions),
+                                streaming=policy.loop.streaming,
+                            )
+                            for transaction in transactions:
+                                in_flight.add(
+                                    asyncio.create_task(
+                                        submit_start_processing(transaction, policy),
+                                    )
+                                )
+                                submitted += 1
+                            continue
+
+                        if in_flight:
+                            await wait_for_completion()
+                            continue
+
+                        self._mark_consumer_progress("idle")
+                        logger.info("Empty fetch detected at %s", datetime.now().isoformat())
+                        if not policy.loop.streaming:
+                            logger.info("Non-streaming mode detected, breaking loop")
+                            break
+
+                        mixin_metrics.record_consumer_empty_queue_wait(
+                            task_name=getattr(self, "name", self.__class__.__name__),
+                            wait_count=empty_count,
+                        )
+                        await utils.backoff_async(
+                            backoff=policy.fetch.empty.backoff,
+                            multiplier=policy.fetch.empty.backoff_multiplier,
+                            cap=policy.fetch.empty.backoff_cap,
+                            attempt=empty_count,
+                        )
+                        empty_count += 1
+                except BaseException:
+                    for task in in_flight:
+                        task.cancel()
+                    if in_flight:
+                        await asyncio.gather(*in_flight, return_exceptions=True)
+                    raise
+
+                elapsed_time = time.perf_counter() - start_time
+                logger.info(
+                    "[Consume continuous] Finished. Processed=%d in %.2f seconds",
+                    processed,
+                    elapsed_time,
+                )
+                return processed
+
+            if policy.loop.mode == "continuous":
+                return await _consume_continuous()
+
             while True:
                 batch_number += 1
 
                 # ============================================================
                 #  FETCH
                 # ============================================================
-                logger.info(f"Fetching transactions batch with fetch policy: {policy.fetch.model_dump_json(indent=2)}")
+                logger.debug(f"Fetching transactions batch with fetch policy: {policy.fetch.model_dump_json(indent=2)}")
                 success, result = await self._handle_fetch(conn, policy.fetch)
 
                 if not success:
@@ -941,7 +1069,7 @@ class AsyncConsumerMixin(ABC):
                 else:
                     batch_context = None  # Use current context
 
-                logger.info(
+                logger.debug(
                     f"Starting batch processing of "
                     f"{len(transactions)} transaction(s) "
                     f"from fetch handler with "

--- a/sdks/python/src/ergon/task/mixins/consumer.py
+++ b/sdks/python/src/ergon/task/mixins/consumer.py
@@ -938,6 +938,17 @@ class AsyncConsumerMixin(ABC):
 
                         if not success:
                             logger.error("Fetch failed → %s", result)
+                            # Unlike shutdown/cancellation, a fetch failure must not
+                            # cancel work already in progress: let in-flight
+                            # transactions finish (bounded by the transaction
+                            # runtime timeout) before propagating the failure.
+                            if in_flight:
+                                logger.warning(
+                                    "Fetch failed with %d transaction(s) in flight; draining before raising",
+                                    len(in_flight),
+                                )
+                                await asyncio.gather(*in_flight, return_exceptions=True)
+                                in_flight.clear()
                             if isinstance(result, (asyncio.TimeoutError, futures.TimeoutError)):
                                 raise exceptions.FetchTimeoutException(str(result))
                             raise exceptions.FetchException(str(result))

--- a/sdks/python/src/ergon/task/policies.py
+++ b/sdks/python/src/ergon/task/policies.py
@@ -170,6 +170,9 @@ class ConsumerLoopPolicy(BaseModel):
     @field_validator("mode", mode="before")
     @classmethod
     def _normalize_mode(cls, v):
+        v = _normalize_optional(v)
+        if v is None:
+            return "batch"
         return v.strip().lower() if isinstance(v, str) else v
 
     @field_validator("timeout", "limit", mode="before")

--- a/sdks/python/src/ergon/task/policies.py
+++ b/sdks/python/src/ergon/task/policies.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -161,10 +161,16 @@ class ExceptionPolicy(BaseModel):
 
 
 class ConsumerLoopPolicy(BaseModel):
+    mode: Literal["batch", "continuous"] = Field(default="batch")
     concurrency: ConcurrencyPolicy = Field(default_factory=ConcurrencyPolicy)
     timeout: Optional[float] = Field(default=None, ge=0)
     limit: Optional[int] = Field(default=None, ge=0)
     streaming: bool = Field(default=False)
+
+    @field_validator("mode", mode="before")
+    @classmethod
+    def _normalize_mode(cls, v):
+        return v.strip().lower() if isinstance(v, str) else v
 
     @field_validator("timeout", "limit", mode="before")
     @classmethod

--- a/sdks/python/tests/task/mixins/test_async_consumer.py
+++ b/sdks/python/tests/task/mixins/test_async_consumer.py
@@ -428,6 +428,143 @@ class TestConsumeStreaming:
 
 
 # =====================================================================
+#   Consume loop — continuous refill
+# =====================================================================
+
+
+class TestConsumeContinuous:
+    async def test_refills_while_slow_transaction_is_running(self):
+        slow_running = asyncio.Event()
+        release_slow = asyncio.Event()
+        refilled_while_slow = False
+
+        class TrackingConnector(MockAsyncConnector):
+            async def fetch_transactions_async(self, batch_size=1, **kwargs):
+                nonlocal refilled_while_slow
+                if slow_running.is_set() and not release_slow.is_set():
+                    refilled_while_slow = True
+                    release_slow.set()
+                return await super().fetch_transactions_async(batch_size, **kwargs)
+
+        async def process(tx):
+            if tx.id == "0":
+                slow_running.set()
+                await release_slow.wait()
+            else:
+                await asyncio.sleep(0.01)
+            return tx.payload
+
+        conn = TrackingConnector(make_transactions(4))
+        consumer = MockAsyncConsumer(connectors={"default": conn}, process_fn=process)
+        policy = policies.ConsumerPolicy(
+            fetch=policies.FetchPolicy(batch=policies.BatchPolicy(size=1)),
+            loop=policies.ConsumerLoopPolicy(
+                mode="continuous",
+                concurrency=policies.ConcurrencyPolicy(value=2),
+            ),
+        )
+
+        result = await asyncio.wait_for(consumer.consume_transactions(policy=policy), timeout=1)
+
+        assert result == 4
+        assert refilled_while_slow is True
+
+    async def test_never_exceeds_concurrency_bound(self):
+        active = 0
+        peak = 0
+
+        async def tracked_process(tx):
+            nonlocal active, peak
+            active += 1
+            peak = max(peak, active)
+            await asyncio.sleep(0.01)
+            active -= 1
+            return tx.payload
+
+        conn = MockAsyncConnector(make_transactions(9))
+        consumer = MockAsyncConsumer(connectors={"default": conn}, process_fn=tracked_process)
+        policy = policies.ConsumerPolicy(
+            loop=policies.ConsumerLoopPolicy(
+                mode="continuous",
+                concurrency=policies.ConcurrencyPolicy(value=3),
+            ),
+        )
+
+        result = await consumer.consume_transactions(policy=policy)
+
+        assert result == 9
+        assert peak == 3
+
+    async def test_non_streaming_drains_queue_and_in_flight_work(self):
+        completed = []
+
+        async def process(tx):
+            await asyncio.sleep(0.01)
+            completed.append(tx.id)
+            return tx.payload
+
+        conn = MockAsyncConnector(make_transactions(7))
+        consumer = MockAsyncConsumer(connectors={"default": conn}, process_fn=process)
+        policy = policies.ConsumerPolicy(
+            loop=policies.ConsumerLoopPolicy(
+                mode="continuous",
+                concurrency=policies.ConcurrencyPolicy(value=3),
+            ),
+        )
+
+        result = await consumer.consume_transactions(policy=policy)
+
+        assert result == 7
+        assert sorted(completed, key=int) == [str(i) for i in range(7)]
+        assert conn._queue == []
+
+    @patch("ergon.task.utils.backoff_async")
+    async def test_streaming_backs_off_then_resumes(self, mock_backoff):
+        conn = MockAsyncConnector([])
+
+        def refill(*args, **kwargs):
+            if mock_backoff.call_count == 2:
+                conn._queue.extend(make_transactions(2))
+
+        mock_backoff.side_effect = refill
+        consumer = MockAsyncConsumer(connectors={"default": conn})
+        policy = policies.ConsumerPolicy(
+            fetch=policies.FetchPolicy(
+                empty=policies.EmptyFetchPolicy(backoff=0.01),
+            ),
+            loop=policies.ConsumerLoopPolicy(
+                mode="continuous",
+                streaming=True,
+                limit=2,
+                concurrency=policies.ConcurrencyPolicy(value=2),
+            ),
+        )
+
+        result = await consumer.consume_transactions(policy=policy)
+
+        assert result == 2
+        assert mock_backoff.call_count == 2
+        assert [call.kwargs["attempt"] for call in mock_backoff.call_args_list] == [0, 1]
+
+    async def test_limit_stops_fetching_and_drains_submitted_work(self):
+        conn = MockAsyncConnector(make_transactions(20))
+        consumer = MockAsyncConsumer(connectors={"default": conn})
+        policy = policies.ConsumerPolicy(
+            loop=policies.ConsumerLoopPolicy(
+                mode="continuous",
+                limit=5,
+                concurrency=policies.ConcurrencyPolicy(value=3),
+            ),
+        )
+
+        result = await consumer.consume_transactions(policy=policy)
+
+        assert result == 5
+        assert len(consumer.processed) == 5
+        assert len(conn._queue) == 15
+
+
+# =====================================================================
 #   Connector resolution
 # =====================================================================
 

--- a/sdks/python/tests/task/mixins/test_async_consumer.py
+++ b/sdks/python/tests/task/mixins/test_async_consumer.py
@@ -546,6 +546,38 @@ class TestConsumeContinuous:
         assert mock_backoff.call_count == 2
         assert [call.kwargs["attempt"] for call in mock_backoff.call_args_list] == [0, 1]
 
+    async def test_fetch_failure_drains_in_flight_before_raising(self):
+        completed = []
+
+        class FailingConnector(MockAsyncConnector):
+            calls = 0
+
+            async def fetch_transactions_async(self, batch_size=1, **kwargs):
+                self.calls += 1
+                if self.calls == 1:
+                    return await super().fetch_transactions_async(batch_size, **kwargs)
+                raise RuntimeError("connection lost")
+
+        async def process(tx):
+            await asyncio.sleep(0.05)
+            completed.append(tx.id)
+            return tx.payload
+
+        conn = FailingConnector(make_transactions(2))
+        consumer = MockAsyncConsumer(connectors={"default": conn}, process_fn=process)
+        policy = policies.ConsumerPolicy(
+            loop=policies.ConsumerLoopPolicy(
+                mode="continuous",
+                streaming=True,
+                concurrency=policies.ConcurrencyPolicy(value=2),
+            ),
+        )
+
+        with pytest.raises(exceptions.FetchException):
+            await consumer.consume_transactions(policy=policy)
+
+        assert sorted(completed) == ["0", "1"]
+
     async def test_limit_stops_fetching_and_drains_submitted_work(self):
         conn = MockAsyncConnector(make_transactions(20))
         consumer = MockAsyncConsumer(connectors={"default": conn})

--- a/sdks/python/tests/task/test_policies.py
+++ b/sdks/python/tests/task/test_policies.py
@@ -1,0 +1,25 @@
+"""Tests for ergon.task.policies — normalization of env-driven values."""
+
+import pytest
+
+from ergon.task import policies
+
+
+class TestConsumerLoopPolicyMode:
+    def test_default_is_batch(self):
+        assert policies.ConsumerLoopPolicy().mode == "batch"
+
+    def test_accepts_continuous(self):
+        assert policies.ConsumerLoopPolicy(mode="continuous").mode == "continuous"
+
+    def test_normalizes_case_and_whitespace(self):
+        assert policies.ConsumerLoopPolicy(mode="  CONTINUOUS ").mode == "continuous"
+
+    def test_empty_and_none_fall_back_to_batch(self):
+        assert policies.ConsumerLoopPolicy(mode="").mode == "batch"
+        assert policies.ConsumerLoopPolicy(mode=None).mode == "batch"
+        assert policies.ConsumerLoopPolicy(mode="none").mode == "batch"
+
+    def test_rejects_unknown_mode(self):
+        with pytest.raises(ValueError):
+            policies.ConsumerLoopPolicy(mode="turbo")

--- a/sdks/python/tests/test_smoke.py
+++ b/sdks/python/tests/test_smoke.py
@@ -4,4 +4,4 @@ import ergon
 
 
 def test_ergon_package_is_importable() -> None:
-    assert ergon.__version__ == "0.1.8"
+    assert ergon.__version__ == "0.1.9"


### PR DESCRIPTION
## Summary
- add an opt-in continuous async consumer loop that refills free concurrency slots without waiting for an entire batch
- preserve batch mode as the backward-compatible default and document scheduling, streaming, prefetch, and limit semantics
- add regression coverage and bump the Python SDK to 0.1.9

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv run pytest -v` (343 passed)

Made with [Cursor](https://cursor.com)