### PR TITLE
fix(rabbitmq): keep async consumers persistent

### DIFF
--- a/docs/modules/3.connector.md
+++ b/docs/modules/3.connector.md
@@ -198,6 +198,8 @@ config = TaskConfig(
 
 The async connector also exposes `ack_transaction()` and `nack_transaction()` methods for manual acknowledgment via the raw AMQP message stored in `Transaction.metadata["_message"]`.
 
+The connector registers one long-lived `basic.consume` callback per queue. RabbitMQ pushes deliveries into an in-memory buffer bounded by the channel's QoS/prefetch window; `fetch_transactions_async()` waits on and drains that local buffer without repeatedly registering and cancelling broker consumers. Idle workers therefore perform no consume/cancel RPC churn, while acknowledgments provide the normal AMQP backpressure signal.
+
 #### Lifecycle and channel cancellation
 
 The async RabbitMQ service maintains **two independent channels** on the same `RobustConnection` — one for consume, one for publish. This isolation prevents a consumer-side outage from poisoning the publish path (and vice-versa).
@@ -209,7 +211,8 @@ When the broker cancels the consumer subscription mid-flight (commonly observed 
   - `ergon.task.exceptions.NackOnDeadChannelError` for nack failures.
   Both are subclasses of `DeadChannelError` and `NonRetryableException`, so the retry helper does not retry them and the consumer mixin can route them deterministically.
 - The async consumer mixin (`AsyncConsumerMixin._start_processing`) recognises a `DeadChannelError` returned from the success handler and **short-circuits the lifecycle**: it logs a single `WARNING` ("broker will redeliver"), records the transaction with `final_status="redeliver"`, and **does not** invoke the exception handler. Routing to the exception handler would only re-fail with another nack on the same dead channel, leaving the prefetch slot held forever — which was the customer-reported wedge symptom. The same short-circuit applies if the exception handler itself fails with `DeadChannelError`.
-- A `channel.add_close_callback` is registered on the consume channel when it is opened (best-effort; falls back silently on aio-pika versions or test mocks that do not expose the API). When the broker closes the channel for any reason, the callback clears the cached channel/queue/exchange handles. The next `consume()` call rebuilds the subscription on a fresh channel, which causes the broker to redeliver any messages that were stuck in the previous prefetch buffer.
+- A close callback is registered on the consume channel when it is opened. When the broker closes the channel, the callback clears the cached topology and local delivery buffer; closing the old channel causes RabbitMQ to redeliver every unacknowledged message.
+- Broker-initiated `Basic.Cancel` removes a consumer tag from aiormq's local registry without invoking aio-pika's delivery callback. Before reusing a subscription, the service verifies that every expected tag remains registered and rebuilds the consume channel if any tag disappeared.
 
 Net effect: a force-recreate while messages are in flight produces a brief WARNING burst and the messages are redelivered automatically to the next consumer. There is no manual restart required and no permanent wedge.
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ergon-framework-python"
-version = "0.1.9"
+version = "0.1.10"
 description = "Ergon internal task-oriented project bootstrapper"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/src/ergon/__init__.py
+++ b/sdks/python/src/ergon/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "manager",
 ]
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"

--- a/sdks/python/src/ergon/connector/rabbitmq/async_service.py
+++ b/sdks/python/src/ergon/connector/rabbitmq/async_service.py
@@ -3,8 +3,8 @@ import json
 import logging
 import ssl as ssl_module
 import time
-from collections import deque
-from typing import Any, AsyncContextManager, Callable, Dict, List, Optional, cast
+from collections.abc import Mapping
+from typing import Any, Awaitable, Callable, Dict, List, Optional, cast
 
 import aio_pika
 import aio_pika.exceptions
@@ -96,7 +96,12 @@ class AsyncRabbitMQService:
         self._consumer_state = "disconnected"
         self._consumer_epoch = 0
         self._in_flight_message_ids: set[int] = set()
-        self._prefetched_messages: deque[Dict[str, Any]] = deque()
+        # AMQP is push-based: one long-lived basic.consume registration per
+        # queue feeds this local buffer. Broker QoS bounds the number of
+        # unacknowledged deliveries, so fetches only drain memory.
+        self._delivery_buffer: asyncio.Queue[tuple[int, Dict[str, Any]]] = asyncio.Queue()
+        self._consumer_setup_lock = asyncio.Lock()
+        self._consumer_config_signature: Optional[str] = None
 
     # ---------- Connection / Channel ----------
 
@@ -184,21 +189,34 @@ class AsyncRabbitMQService:
             logger.warning("Error closing RabbitMQ connection (%s): %r", reason, exc)
 
     def _invalidate_consume_channel(self, reason: str = "explicit invalidation") -> None:
-        """Drop cached consume channel + queue/exchange handles.
+        """Drop the consume topology and buffered deliveries.
 
         Called when the consume channel is closed by the broker (e.g. after
         a Basic.Cancel during force-recreate) or when an ack/nack discovers
         the channel is dead. The next ``consume()`` call will then rebuild
-        the subscription on a fresh channel, which causes the broker to
-        redeliver any messages that were stuck in the previous prefetch
-        buffer to the dead consumer tag.
+        long-lived subscriptions on a fresh channel. Closing the old channel
+        makes RabbitMQ redeliver every unacknowledged buffered message.
         """
-        if self._consume_channel is None and not self._queues and not self._exchanges:
+        if (
+            self._consume_channel is None
+            and not self._queues
+            and not self._exchanges
+            and not self._active_consumer_tags
+            and self._delivery_buffer.empty()
+        ):
             return
         logger.warning("Invalidating consume channel cache (%s)", reason)
         self._consume_channel = None
         self._queues.clear()
         self._exchanges.clear()
+        self._active_consumer_tag = None
+        self._active_consumer_tags.clear()
+        self._consumer_config_signature = None
+        while not self._delivery_buffer.empty():
+            try:
+                self._delivery_buffer.get_nowait()
+            except asyncio.QueueEmpty:
+                break
 
     async def _teardown_consume_channel(self, reason: str = "explicit teardown") -> None:
         """Deterministically tear down the consume channel.
@@ -207,26 +225,16 @@ class AsyncRabbitMQService:
         references), this snapshots the live channel, clears the cache, then
         explicitly ``close()``-es the channel. Closing the channel:
 
-        * drops every consumer registered on it at the broker — this is what
-          eliminates the *zombie consumer* left behind by a broker-initiated
-          ``Basic.Cancel`` that the per-fetch iterator could not cancel
-          cleanly; and
+        * drops every long-lived consumer registered on it at the broker; and
         * for a ``RobustChannel`` removes it from aio_pika's reconnection set,
-          so the robust layer does not silently restore the dead consumer on
+          so the robust layer does not silently restore dead consumers on
           the next reconnect.
-
-        It also prevents the channel leak: previously the dropped channel
-        object was orphaned without ever being closed, so its broker-side
-        channel lingered and ``ChannelCount`` climbed over time.
         """
         channel = self._consume_channel
         self._invalidate_consume_channel(reason)
-        self._active_consumer_tag = None
-        self._active_consumer_tags.clear()
         self._consumer_epoch += 1
         self._consumer_state = "channel_dead"
         self._in_flight_message_ids.clear()
-        self._prefetched_messages.clear()
         await self._close_channel_safely(channel, reason)
 
     async def _close_channel_safely(self, channel: Optional[AbstractChannel], reason: str) -> None:
@@ -251,14 +259,13 @@ class AsyncRabbitMQService:
         channel's consumers at the broker and avoid the channel leak.
         """
         channel = self._consume_channel
+        if channel is None:
+            return
         self._invalidate_consume_channel(reason)
-        self._active_consumer_tag = None
-        self._active_consumer_tags.clear()
         self._consumer_epoch += 1
         self._consumer_state = "channel_dead"
         self._in_flight_message_ids.clear()
-        self._prefetched_messages.clear()
-        if channel is None or channel.is_closed:
+        if channel.is_closed:
             return
         try:
             loop = asyncio.get_running_loop()
@@ -286,19 +293,24 @@ class AsyncRabbitMQService:
                 self._consumer_state = "connect_stalled"
                 await self._reset_connection("consume channel creation timed out")
                 raise
-            # ``add_close_callback`` is not part of the abstract interface
-            # but is provided by the concrete ``Channel`` class. Older
-            # aio_pika versions and test mocks may not expose it, so we
-            # access via getattr and skip silently when absent — the
-            # consume() path also self-heals via is_closed checks.
-            register_close = getattr(self._consume_channel, "add_close_callback", None)
+            # aio-pika exposes close_callbacks on current releases; retain the
+            # legacy add_close_callback fallback for older supported versions.
+            close_callbacks = getattr(self._consume_channel, "close_callbacks", None)
+            register_close = getattr(close_callbacks, "add", None)
             if callable(register_close):
                 try:
-                    register_close(self._on_consume_channel_close)
+                    register_close(self._on_consume_channel_close, weak=True)
                 except TypeError:
                     logger.debug("Consume channel close-callback registration rejected; skipping")
             else:
-                logger.debug("Consume channel does not support add_close_callback; skipping registration")
+                register_close = getattr(self._consume_channel, "add_close_callback", None)
+                if callable(register_close):
+                    try:
+                        register_close(self._on_consume_channel_close)
+                    except TypeError:
+                        logger.debug("Legacy consume channel close-callback registration rejected; skipping")
+                else:
+                    logger.debug("Consume channel does not expose close callbacks; skipping registration")
             if prefetch_count is not None:
                 await self._consume_channel.set_qos(prefetch_count=prefetch_count)
                 logger.debug("Consume channel QoS set to prefetch_count=%d", prefetch_count)
@@ -394,82 +406,47 @@ class AsyncRabbitMQService:
         config: AsyncRabbitmqConsumerConfig,
         batch_size: int = 1,
     ) -> List[Dict[str, Any]]:
-        """
-        Fetch up to batch_size messages from the configured queue.
+        """Read up to ``batch_size`` deliveries from persistent consumers.
 
-        Declares every configured exchange/queue/binding on first call, then
-        concurrently iterates the queues until batch_size is reached or
-        consume_timeout elapses.
-
-        Returns raw message dicts without acknowledging — the caller
-        is responsible for ack/nack via the delivery_tag in metadata.
+        Queue subscriptions are registered once per consume-channel epoch.
+        RabbitMQ pushes deliveries into a local buffer subject to channel QoS;
+        this method waits for the first delivery and then drains only messages
+        already available. The caller remains responsible for ack/nack.
         """
+        if batch_size <= 0:
+            return []
+
         self._last_poll_started_ts = time.time()
         self._consumer_state = "subscribing"
         poll_completed = False
 
         try:
-            # Ensure the consume channel exists with the requested prefetch QoS.
-            # The return value is unused here because declarations re-fetch the
-            # channel from the cache.
-            await self._get_consume_channel(prefetch_count=config.prefetch_count)
-
-            queues: list[tuple[str, AbstractQueue]] = []
-            for subscription in config.resolved_subscriptions():
-                queue = await self.declare_queue(
-                    subscription.queue_name,
-                    durable=config.durable,
-                    arguments=subscription.queue_arguments or None,
-                )
-                for binding in subscription.bindings:
-                    exchange = await self.declare_exchange(
-                        binding.exchange_name,
-                        binding.exchange_type,
-                        durable=config.durable,
-                    )
-                    for key in binding.routing_keys:
-                        await self.bind_queue(queue, exchange, key)
-                queues.append((subscription.queue_name, queue))
+            await self._ensure_consumers(config)
         except Exception as exc:
             if not _is_recoverable_broker_interruption(exc):
                 raise
-            await self._teardown_consume_channel(f"subscription setup interrupted: {exc!r}")
+            if self._consume_channel is not None:
+                await self._teardown_consume_channel(f"subscription setup interrupted: {exc!r}")
             return []
 
         buffer: List[Dict[str, Any]] = []
-        timeout = config.consume_timeout
-        while self._prefetched_messages and len(buffer) < batch_size:
-            buffer.append(self._prefetched_messages.popleft())
-
         try:
             self._consumer_state = "polling"
-            if len(buffer) < batch_size:
-                async with timeout_after(timeout):
-                    await self._consume_queues(
-                        queues,
-                        buffer,
-                        batch_size=batch_size,
-                        auto_ack=config.auto_ack,
-                    )
+            async with timeout_after(config.consume_timeout):
+                buffer.append(await self._next_current_delivery())
+
+            while len(buffer) < batch_size:
+                try:
+                    epoch, delivery = self._delivery_buffer.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                if epoch == self._consumer_epoch:
+                    buffer.append(delivery)
         except TimeoutError:
             poll_completed = True
-        except Exception as exc:
-            if not _is_recoverable_broker_interruption(exc):
-                raise
-            # Broker cancelled this subscription mid-iteration; deterministically
-            # tear down (cancel consumers + close) the dead channel so the next
-            # call rebuilds against a fresh consumer, the broker redelivers what
-            # we had prefetched, and no zombie consumer / leaked channel is left
-            # behind.
-            await self._teardown_consume_channel(f"consume aborted: {exc!r}")
-            return buffer
         else:
             poll_completed = True
         finally:
-            self._active_consumer_tag = None
-            self._active_consumer_tags.clear()
-            # If the channel was closed during iteration, make sure we don't
-            # hand back a stale cache to the next caller.
             if self._consume_channel is not None and self._consume_channel.is_closed:
                 await self._teardown_consume_channel("consume channel observed closed after iteration")
             if poll_completed:
@@ -478,134 +455,112 @@ class AsyncRabbitMQService:
 
         return buffer
 
-    async def _consume_queues(
-        self,
-        queues: list[tuple[str, AbstractQueue]],
-        buffer: List[Dict[str, Any]],
-        *,
-        batch_size: int,
-        auto_ack: bool,
-    ) -> None:
-        """Wait for one delivery, then drain only messages already available.
+    async def _ensure_consumers(self, config: AsyncRabbitmqConsumerConfig) -> None:
+        """Declare topology and register one persistent consumer per queue."""
+        signature = config.model_dump_json()
 
-        ``consume_timeout`` bounds the idle wait in :meth:`consume`; it must
-        not become a batch-assembly delay after the first delivery. Once any
-        message is buffered, give newly scheduled iterator reads one event-loop
-        turn to complete and return immediately if none are ready.
-        """
-        pending: dict[asyncio.Task, tuple[str, Any]] = {}
-        iterator_contexts: list[AsyncContextManager[Any]] = []
-        try:
-            for queue_name, queue in queues:
-                iterator_context = cast(
-                    AsyncContextManager[Any],
-                    # The framework owns consumer teardown/resubscription.
-                    # Letting aio-pika restore these short-lived per-fetch
-                    # consumers can resurrect an iterator with no pending
-                    # reader after a broker restart, creating a zombie tag.
-                    queue.iterator(no_ack=auto_ack, robust=False),
-                )
-                iterator = await iterator_context.__aenter__()
-                iterator_contexts.append(iterator_context)
-                self._register_consumer_cancel_callback(iterator)
-                consumer_tag = getattr(iterator, "_consumer_tag", None) or getattr(iterator, "consumer_tag", None)
-                if consumer_tag:
-                    self._active_consumer_tags[queue_name] = consumer_tag
-                pending[asyncio.create_task(anext(iterator))] = (queue_name, iterator)
+        async with self._consumer_setup_lock:
+            if (
+                self._consumer_config_signature == signature
+                and self._active_consumer_tags
+                and self._consume_channel is not None
+                and not self._consume_channel.is_closed
+            ):
+                if await self._consumer_tags_registered():
+                    return
+                await self._teardown_consume_channel("broker cancelled a registered consumer")
 
-            self._active_consumer_tag = next(iter(self._active_consumer_tags.values()), None)
-            while pending and len(buffer) < batch_size:
-                if buffer:
-                    done = {task for task in pending if task.done()}
-                    if not done:
-                        await asyncio.sleep(0)
-                        done = {task for task in pending if task.done()}
-                    if not done:
-                        break
-                else:
-                    done, _ = await asyncio.wait(
-                        pending,
-                        return_when=asyncio.FIRST_COMPLETED,
-                    )
-                for task in done:
-                    queue_name, iterator = pending.pop(task)
-                    try:
-                        message = task.result()
-                    except StopAsyncIteration:
-                        self._active_consumer_tags.pop(queue_name, None)
-                        continue
+            if self._consumer_config_signature is not None and self._consumer_config_signature != signature:
+                await self._teardown_consume_channel("consumer configuration changed")
 
-                    message_dict = self._message_to_dict(message, queue_name=queue_name)
-                    self._in_flight_message_ids.add(id(message))
-                    self._last_fetch_ts = time.time()
-                    self._consumer_state = "delivering"
-                    if len(buffer) < batch_size:
-                        buffer.append(message_dict)
-                    else:
-                        self._prefetched_messages.append(message_dict)
-                    if len(buffer) < batch_size:
-                        pending[asyncio.create_task(anext(iterator))] = (queue_name, iterator)
-        finally:
-            cleanup_timeout = min(1.0, self.client.channel_timeout)
-            cleanup_failed = False
-            for task in pending:
-                task.cancel()
-            if pending:
-                try:
-                    async with timeout_after(cleanup_timeout):
-                        await asyncio.gather(*pending, return_exceptions=True)
-                except TimeoutError:
-                    cleanup_failed = True
-                    logger.warning("Timed out cancelling RabbitMQ iterator reads")
-            cleanup_failed = await self._close_iterator_contexts(iterator_contexts) or cleanup_failed
-            if cleanup_failed:
-                await self._teardown_consume_channel("queue iterator cleanup failed")
+            await self._get_consume_channel(prefetch_count=config.prefetch_count)
+            epoch = self._consumer_epoch
+            registered_tags: Dict[str, str] = {}
 
-    async def _close_iterator_contexts(
-        self,
-        iterator_contexts: list[AsyncContextManager[Any]],
-    ) -> bool:
-        """Bound queue-iterator cleanup so a dead broker cannot stall a poll."""
-        cleanup_timeout = min(1.0, self.client.channel_timeout)
-        cleanup_failed = False
-        for iterator_context in reversed(iterator_contexts):
             try:
-                async with timeout_after(cleanup_timeout):
-                    await iterator_context.__aexit__(None, None, None)
-            except Exception as exc:
-                cleanup_failed = True
-                logger.warning("RabbitMQ queue iterator cleanup failed: %r", exc)
-        return cleanup_failed
+                for subscription in config.resolved_subscriptions():
+                    queue = await self.declare_queue(
+                        subscription.queue_name,
+                        durable=config.durable,
+                        arguments=subscription.queue_arguments or None,
+                    )
+                    for binding in subscription.bindings:
+                        exchange = await self.declare_exchange(
+                            binding.exchange_name,
+                            binding.exchange_type,
+                            durable=config.durable,
+                        )
+                        for key in binding.routing_keys:
+                            await self.bind_queue(queue, exchange, key)
 
-    def _register_consumer_cancel_callback(self, iterator: Any) -> None:
-        """Best-effort registration of an on-cancel callback on the iterator's consumer.
+                    queue_name = subscription.queue_name
 
-        ``aio_pika`` does not expose a stable public API for this across
-        versions; we probe for known attributes and fall back silently.
-        The channel close callback in :meth:`_get_consume_channel` provides
-        the primary defence — this is belt-and-braces.
+                    async def on_delivery(
+                        message: AbstractIncomingMessage,
+                        *,
+                        delivery_queue_name: str = queue_name,
+                        delivery_epoch: int = epoch,
+                        delivery_auto_ack: bool = config.auto_ack,
+                    ) -> None:
+                        if delivery_epoch != self._consumer_epoch:
+                            return
+                        if not delivery_auto_ack:
+                            self._in_flight_message_ids.add(id(message))
+                        self._last_fetch_ts = time.time()
+                        self._consumer_state = "delivering"
+                        self._delivery_buffer.put_nowait(
+                            (
+                                delivery_epoch,
+                                self._message_to_dict(message, queue_name=delivery_queue_name),
+                            )
+                        )
+
+                    consumer_tag = await queue.consume(
+                        on_delivery,
+                        no_ack=config.auto_ack,
+                        robust=False,  # type: ignore[call-arg]
+                    )
+                    registered_tags[queue_name] = consumer_tag
+            except BaseException:
+                await self._teardown_consume_channel("consumer subscription failed")
+                raise
+
+            self._active_consumer_tags = registered_tags
+            self._active_consumer_tag = next(iter(registered_tags.values()), None)
+            self._consumer_config_signature = signature
+            self._consumer_state = "subscribed"
+
+    async def _consumer_tags_registered(self) -> bool:
+        """Best-effort detection of broker-initiated Basic.Cancel.
+
+        aio-pika does not surface Basic.Cancel to queue callbacks, while
+        aiormq removes the tag from its local consumer registry. Inspecting
+        that local mapping lets the next fetch rebuild a cancelled topology
+        without another broker round trip.
         """
-        candidate: Optional[Callable[[Callable[..., Any]], Any]] = None
-        for attr in ("add_on_cancel_callback", "add_close_callback"):
-            consumer_obj = getattr(iterator, "_consumer", None) or getattr(iterator, "consumer", None)
-            if consumer_obj is not None:
-                candidate = getattr(consumer_obj, attr, None)
-                if candidate is not None:
-                    break
-            candidate = getattr(iterator, attr, None)
-            if candidate is not None:
-                break
-
-        if candidate is None:
-            return
-
-        def _on_cancel(*_args: Any, **_kwargs: Any) -> None:
-            self._schedule_teardown("consumer cancelled by broker (Basic.Cancel)")
-
+        channel = self._consume_channel
+        if channel is None:
+            return False
+        get_underlay_channel = getattr(channel, "get_underlay_channel", None)
+        if not callable(get_underlay_channel):
+            return True
+        get_underlay_channel = cast(Callable[[], Awaitable[Any]], get_underlay_channel)
         try:
-            candidate(_on_cancel)
-        except (TypeError, AttributeError):
-            logger.debug("Iterator consumer does not accept cancel callback; skipping")
+            async with timeout_after(self.client.channel_timeout):
+                underlay_channel = await get_underlay_channel()
+        except Exception:
+            return False
+        consumers = getattr(underlay_channel, "consumers", None)
+        if not isinstance(consumers, Mapping):
+            return True
+        return set(self._active_consumer_tags.values()).issubset(consumers)
+
+    async def _next_current_delivery(self) -> Dict[str, Any]:
+        """Discard stale-epoch entries and return the next live delivery."""
+        while True:
+            epoch, delivery = await self._delivery_buffer.get()
+            if epoch == self._consumer_epoch:
+                return delivery
 
     @staticmethod
     def _message_to_dict(message: AbstractIncomingMessage, queue_name: Optional[str] = None) -> Dict[str, Any]:
@@ -740,6 +695,7 @@ class AsyncRabbitMQService:
             "consume_channel_open": consume_channel_open,
             "active_consumer_tag": self._active_consumer_tag,
             "active_consumer_tags": dict(self._active_consumer_tags),
+            "buffered_delivery_count": self._delivery_buffer.qsize(),
             "in_flight_count": len(self._in_flight_message_ids),
             "last_poll_started_ts": self._last_poll_started_ts,
             "last_poll_completed_ts": self._last_poll_completed_ts,
@@ -762,25 +718,16 @@ class AsyncRabbitMQService:
     # ---------- Lifecycle ----------
 
     async def close(self) -> None:
-        self._exchanges.clear()
-        self._queues.clear()
+        await self._teardown_consume_channel("service close")
 
-        for attr_name in ("_consume_channel", "_publish_channel"):
-            channel = getattr(self, attr_name)
-            if channel is not None and not channel.is_closed:
-                try:
-                    await channel.close()
-                except Exception as exc:
-                    logger.warning("Error closing %s: %r", attr_name, exc)
-            setattr(self, attr_name, None)
+        publish_channel = self._publish_channel
+        self._publish_channel = None
+        await self._close_channel_safely(publish_channel, "service close")
 
         connection = self._connection
         self._connection = None
         await self._close_connection_safely(connection, "service close")
 
-        self._active_consumer_tag = None
-        self._active_consumer_tags.clear()
         self._in_flight_message_ids.clear()
-        self._prefetched_messages.clear()
         self._consumer_state = "closed"
         logger.info("RabbitMQ connection closed")

--- a/sdks/python/src/ergon/connector/rabbitmq/models.py
+++ b/sdks/python/src/ergon/connector/rabbitmq/models.py
@@ -125,6 +125,7 @@ class AsyncRabbitmqConsumerConfig(BaseModel):
     )
     prefetch_count: int = Field(
         default=10,
+        gt=0,
         description=(
             "Number of unacknowledged messages allowed. Recommended: set equal to the "
             "consumer loop concurrency. A prefetch larger than concurrency lets idle "

--- a/sdks/python/tests/connector/rabbitmq/test_async_service.py
+++ b/sdks/python/tests/connector/rabbitmq/test_async_service.py
@@ -1,11 +1,9 @@
 """Tests for AsyncRabbitMQService — connection lifecycle, consume, publish, ack/nack."""
 
 import asyncio
-import builtins
 import json
 import time
-from contextlib import asynccontextmanager
-from typing import Any, AsyncContextManager
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aio_pika.exceptions
@@ -58,11 +56,34 @@ def _mock_channel() -> AsyncMock:
     """Mock channel that mirrors the sync/async surface ``AsyncRabbitMQService`` uses."""
     channel = AsyncMock()
     channel.is_closed = False
-    # add_close_callback is a sync method on real aio_pika channels; using
-    # AsyncMock here would create unawaited-coroutine warnings.
+    channel.close_callbacks = MagicMock()
+    channel.close_callbacks.add = MagicMock()
+    # Legacy fallback is also synchronous on older aio-pika channels.
     channel.add_close_callback = MagicMock()
     channel.set_qos = AsyncMock()
     return channel
+
+
+def _mock_consumer_queue(
+    *,
+    name: str = "test-queue",
+    messages: list[Any] | None = None,
+    consumer_tag: str | None = None,
+) -> tuple[MagicMock, list[Any]]:
+    """Build a queue whose long-lived consumer can receive test deliveries."""
+    callbacks: list[Any] = []
+
+    async def consume(callback, **_kwargs):
+        callbacks.append(callback)
+        for message in messages or []:
+            await callback(message)
+        return consumer_tag or f"ctag-{name}"
+
+    queue = MagicMock()
+    queue.name = name
+    queue.consume = AsyncMock(side_effect=consume)
+    queue.bind = AsyncMock()
+    return queue, callbacks
 
 
 class TestClientUrl:
@@ -186,6 +207,23 @@ class TestConnection:
         mock_connect.assert_awaited_once()
 
     @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
+    async def test_consume_channel_registers_current_close_callback_api(self, mock_connect):
+        mock_channel = _mock_channel()
+        mock_conn = AsyncMock()
+        mock_conn.is_closed = False
+        mock_conn.channel = AsyncMock(return_value=mock_channel)
+        mock_connect.return_value = mock_conn
+
+        service = AsyncRabbitMQService(_make_client())
+        await service._get_consume_channel()
+
+        mock_channel.close_callbacks.add.assert_called_once_with(
+            service._on_consume_channel_close,
+            weak=True,
+        )
+        mock_channel.add_close_callback.assert_not_called()
+
+    @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
     async def test_ssl_connection(self, mock_connect):
         mock_conn = AsyncMock()
         mock_conn.is_closed = False
@@ -230,24 +268,14 @@ class TestConsume:
         with pytest.raises(ValueError, match="only once"):
             AsyncRabbitmqConsumerConfig(subscriptions=[duplicate, duplicate])
 
+    def test_prefetch_must_bound_the_delivery_buffer(self):
+        with pytest.raises(ValueError, match="greater than 0"):
+            AsyncRabbitmqConsumerConfig(queue_name="test-queue", prefetch_count=0)
+
     @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
     async def test_consume_returns_messages(self, mock_connect):
         msg = _mock_message()
-        iterator_kwargs: dict[str, Any] = {}
-
-        @asynccontextmanager
-        async def _iterator_cm(**kwargs):
-            iterator_kwargs.update(kwargs)
-
-            async def _gen():
-                yield msg
-
-            yield _gen()
-
-        mock_queue = MagicMock()
-        mock_queue.name = "test-queue"
-        mock_queue.iterator = _iterator_cm
-        mock_queue.bind = AsyncMock()
+        mock_queue, _callbacks = _mock_consumer_queue(messages=[msg])
 
         mock_exchange = AsyncMock()
         mock_exchange.name = "test-exchange"
@@ -275,25 +303,33 @@ class TestConsume:
         assert result[0]["body"] == {"key": "val"}
         assert result[0]["routing_key"] == "test.key"
         assert result[0]["delivery_tag"] == 1
-        assert iterator_kwargs == {"no_ack": False, "robust": False}
+        mock_queue.consume.assert_awaited_once()
+        _, consume_kwargs = mock_queue.consume.call_args
+        assert consume_kwargs == {"no_ack": False, "robust": False}
+
+    @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
+    async def test_auto_ack_delivery_is_not_tracked_as_in_flight(self, mock_connect):
+        mock_queue, _callbacks = _mock_consumer_queue(messages=[_mock_message()])
+        mock_channel = _mock_channel()
+        mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
+        mock_conn = AsyncMock()
+        mock_conn.is_closed = False
+        mock_conn.channel = AsyncMock(return_value=mock_channel)
+        mock_connect.return_value = mock_conn
+
+        service = AsyncRabbitMQService(_make_client())
+        config = AsyncRabbitmqConsumerConfig(
+            queue_name="test-queue",
+            auto_ack=True,
+        )
+
+        assert len(await service.consume(config)) == 1
+        assert service.health()["in_flight_count"] == 0
 
     @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
     async def test_consume_returns_first_delivery_without_waiting_to_fill_batch(self, mock_connect):
         first_message = _mock_message(delivery_tag=1)
-        second_message = _mock_message(delivery_tag=2)
-        release_second = asyncio.Event()
-
-        @asynccontextmanager
-        async def _iterator_cm(**kwargs):
-            async def _gen():
-                yield first_message
-                await release_second.wait()
-                yield second_message
-
-            yield _gen()
-
-        mock_queue = MagicMock()
-        mock_queue.iterator = _iterator_cm
+        mock_queue, _callbacks = _mock_consumer_queue(messages=[first_message])
 
         mock_channel = _mock_channel()
         mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
@@ -316,17 +352,7 @@ class TestConsume:
     @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
     async def test_consume_nonblocking_drains_immediately_available_messages(self, mock_connect):
         messages = [_mock_message(delivery_tag=index) for index in range(1, 4)]
-
-        @asynccontextmanager
-        async def _iterator_cm(**kwargs):
-            async def _gen():
-                for message in messages:
-                    yield message
-
-            yield _gen()
-
-        mock_queue = MagicMock()
-        mock_queue.iterator = _iterator_cm
+        mock_queue, _callbacks = _mock_consumer_queue(messages=messages)
 
         mock_channel = _mock_channel()
         mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
@@ -349,29 +375,11 @@ class TestConsume:
     @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
     async def test_consume_merges_multiple_queue_subscriptions(self, mock_connect):
         first_message = _mock_message(routing_key="iam.created", delivery_tag=7)
-
-        @asynccontextmanager
-        async def _ready_iterator(**kwargs):
-            async def _gen():
-                yield first_message
-
-            yield _gen()
-
-        @asynccontextmanager
-        async def _idle_iterator(**kwargs):
-            async def _gen():
-                await asyncio.sleep(10)
-                return
-                yield
-
-            yield _gen()
-
-        queue_one = MagicMock()
-        queue_one.iterator = _ready_iterator
-        queue_one.bind = AsyncMock()
-        queue_two = MagicMock()
-        queue_two.iterator = _idle_iterator
-        queue_two.bind = AsyncMock()
+        queue_one, _callbacks_one = _mock_consumer_queue(
+            name="audit.iam",
+            messages=[first_message],
+        )
+        queue_two, _callbacks_two = _mock_consumer_queue(name="audit.cross-service")
 
         exchanges = {
             "iam": MagicMock(name="iam"),
@@ -428,20 +436,14 @@ class TestConsume:
 
     @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
     async def test_simultaneous_deliveries_do_not_exceed_batch_size(self, mock_connect):
-        def queue_with_message(message):
-            @asynccontextmanager
-            async def _iterator(**kwargs):
-                async def _gen():
-                    yield message
-
-                yield _gen()
-
-            queue = MagicMock()
-            queue.iterator = _iterator
-            return queue
-
-        queue_one = queue_with_message(_mock_message(delivery_tag=1))
-        queue_two = queue_with_message(_mock_message(delivery_tag=2))
+        queue_one, _callbacks_one = _mock_consumer_queue(
+            name="one",
+            messages=[_mock_message(delivery_tag=1)],
+        )
+        queue_two, _callbacks_two = _mock_consumer_queue(
+            name="two",
+            messages=[_mock_message(delivery_tag=2)],
+        )
         mock_channel = _mock_channel()
         mock_channel.declare_queue = AsyncMock(side_effect=[queue_one, queue_two])
 
@@ -475,18 +477,7 @@ class TestConsume:
         TTL configuration a no-op in production.
         """
 
-        @asynccontextmanager
-        async def _iterator_cm(**kwargs):
-            async def _gen():
-                await asyncio.sleep(10)
-                return
-                yield  # make it an async generator
-
-            yield _gen()
-
-        mock_queue = MagicMock()
-        mock_queue.name = "test-queue"
-        mock_queue.iterator = _iterator_cm
+        mock_queue, _callbacks = _mock_consumer_queue()
 
         mock_channel = _mock_channel()
         mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
@@ -526,18 +517,7 @@ class TestConsume:
         PRECONDITION_FAILED on inequivalent args).
         """
 
-        @asynccontextmanager
-        async def _iterator_cm(**kwargs):
-            async def _gen():
-                await asyncio.sleep(10)
-                return
-                yield
-
-            yield _gen()
-
-        mock_queue = MagicMock()
-        mock_queue.name = "test-queue"
-        mock_queue.iterator = _iterator_cm
+        mock_queue, _callbacks = _mock_consumer_queue()
 
         mock_channel = _mock_channel()
         mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
@@ -579,18 +559,7 @@ class TestConsume:
 
     @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
     async def test_consume_empty_queue_timeout(self, mock_connect):
-        @asynccontextmanager
-        async def _iterator_cm(**kwargs):
-            async def _gen():
-                await asyncio.sleep(10)
-                return
-                yield  # make it an async generator
-
-            yield _gen()
-
-        mock_queue = MagicMock()
-        mock_queue.name = "test-queue"
-        mock_queue.iterator = _iterator_cm
+        mock_queue, _callbacks = _mock_consumer_queue()
 
         mock_channel = _mock_channel()
         mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
@@ -680,23 +649,8 @@ class TestConsume:
             await service.consume(config, batch_size=10)
 
     @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
-    async def test_consume_bounds_iterator_cleanup_when_broker_is_unresponsive(self, mock_connect):
-        class HangingIteratorContext:
-            async def __aenter__(self):
-                async def _gen():
-                    await asyncio.sleep(10)
-                    return
-                    yield
-
-                return _gen()
-
-            async def __aexit__(self, exc_type, exc, traceback):
-                await asyncio.sleep(10)
-
-        mock_queue = MagicMock()
-        mock_queue.name = "test-queue"
-        mock_queue.iterator.return_value = HangingIteratorContext()
-
+    async def test_repeated_fetches_reuse_one_registered_consumer(self, mock_connect):
+        mock_queue, _callbacks = _mock_consumer_queue()
         mock_channel = _mock_channel()
         mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
 
@@ -705,44 +659,58 @@ class TestConsume:
         mock_conn.channel = AsyncMock(return_value=mock_channel)
         mock_connect.return_value = mock_conn
 
-        service = AsyncRabbitMQService(_make_client(channel_timeout=0.1))
+        service = AsyncRabbitMQService(_make_client())
         config = AsyncRabbitmqConsumerConfig(
             queue_name="test-queue",
-            consume_timeout=0.05,
+            consume_timeout=0.001,
         )
 
-        started = time.monotonic()
-        result = await asyncio.wait_for(service.consume(config, batch_size=10), timeout=0.5)
+        for _ in range(100):
+            assert await service.consume(config, batch_size=10) == []
 
-        assert result == []
-        assert time.monotonic() - started < 0.5
-        mock_channel.close.assert_awaited_once()
+        mock_queue.consume.assert_awaited_once()
+        assert mock_queue.iterator.call_count == 0
+        assert service.health()["active_consumer_tags"] == {"test-queue": "ctag-test-queue"}
+
+    @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
+    async def test_broker_cancelled_consumer_is_rebuilt_on_next_fetch(self, mock_connect):
+        first_queue, _first_callbacks = _mock_consumer_queue(consumer_tag="ctag-old")
+        second_queue, _second_callbacks = _mock_consumer_queue(
+            messages=[_mock_message(delivery_tag=2)],
+            consumer_tag="ctag-new",
+        )
+        underlay_channel = MagicMock()
+        underlay_channel.consumers = {"ctag-old": MagicMock()}
+
+        first_channel = _mock_channel()
+        first_channel.declare_queue = AsyncMock(return_value=first_queue)
+        first_channel.get_underlay_channel = AsyncMock(return_value=underlay_channel)
+        second_channel = _mock_channel()
+        second_channel.declare_queue = AsyncMock(return_value=second_queue)
+
+        mock_conn = AsyncMock()
+        mock_conn.is_closed = False
+        mock_conn.channel = AsyncMock(side_effect=[first_channel, second_channel])
+        mock_connect.return_value = mock_conn
+
+        service = AsyncRabbitMQService(_make_client())
+        config = AsyncRabbitmqConsumerConfig(
+            queue_name="test-queue",
+            consume_timeout=0.001,
+        )
+
+        assert await service.consume(config) == []
+        underlay_channel.consumers.clear()
+        result = await service.consume(config)
+
+        assert result[0]["delivery_tag"] == 2
+        first_channel.close.assert_awaited_once()
+        assert service.health()["active_consumer_tags"] == {"test-queue": "ctag-new"}
         assert service.health()["consumer_epoch"] == 1
 
     @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
-    async def test_consume_bounds_pending_iterator_cancellation(self, mock_connect):
-        class StubbornIterator:
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                try:
-                    await asyncio.sleep(10)
-                except asyncio.CancelledError:
-                    await asyncio.sleep(10)
-                raise StopAsyncIteration
-
-        class IteratorContext:
-            async def __aenter__(self):
-                return StubbornIterator()
-
-            async def __aexit__(self, exc_type, exc, traceback):
-                return None
-
-        mock_queue = MagicMock()
-        mock_queue.name = "test-queue"
-        mock_queue.iterator.return_value = IteratorContext()
-
+    async def test_cancelled_fetch_keeps_subscription_alive(self, mock_connect):
+        mock_queue, callbacks = _mock_consumer_queue()
         mock_channel = _mock_channel()
         mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
 
@@ -751,53 +719,56 @@ class TestConsume:
         mock_conn.channel = AsyncMock(return_value=mock_channel)
         mock_connect.return_value = mock_conn
 
-        service = AsyncRabbitMQService(_make_client(channel_timeout=0.1))
+        service = AsyncRabbitMQService(_make_client())
         config = AsyncRabbitmqConsumerConfig(
             queue_name="test-queue",
-            consume_timeout=0.05,
+            consume_timeout=10,
         )
 
-        started = time.monotonic()
-        result = await asyncio.wait_for(service.consume(config, batch_size=10), timeout=0.5)
+        waiting_fetch = asyncio.create_task(service.consume(config, batch_size=1))
+        await asyncio.sleep(0)
+        waiting_fetch.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiting_fetch
 
-        assert result == []
-        assert time.monotonic() - started < 0.5
-        mock_channel.close.assert_awaited_once()
-        assert service.health()["consumer_epoch"] == 1
+        await callbacks[0](_mock_message(delivery_tag=42))
+        result = await service.consume(config, batch_size=1)
 
-    async def test_iterator_cleanup_continues_after_exception_group(self):
-        exception_group_type = getattr(builtins, "ExceptionGroup", None)
-        if exception_group_type is None:
-            pytest.skip("ExceptionGroup requires Python 3.11+")
+        assert result[0]["delivery_tag"] == 42
+        mock_queue.consume.assert_awaited_once()
 
-        closed: list[str] = []
+    @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
+    async def test_teardown_discards_buffer_and_stale_epoch_deliveries(self, mock_connect):
+        first_queue, first_callbacks = _mock_consumer_queue(name="test-queue", consumer_tag="ctag-old")
+        second_queue, second_callbacks = _mock_consumer_queue(name="test-queue", consumer_tag="ctag-new")
+        first_channel = _mock_channel()
+        first_channel.declare_queue = AsyncMock(return_value=first_queue)
+        second_channel = _mock_channel()
+        second_channel.declare_queue = AsyncMock(return_value=second_queue)
 
-        class IteratorContext:
-            def __init__(self, name: str, *, fail: bool = False):
-                self.name = name
-                self.fail = fail
-
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, exc_type, exc, traceback):
-                closed.append(self.name)
-                if self.fail:
-                    raise exception_group_type(
-                        "buffered message cleanup failed",
-                        [RuntimeError("nack failed")],
-                    )
+        mock_conn = AsyncMock()
+        mock_conn.is_closed = False
+        mock_conn.channel = AsyncMock(side_effect=[first_channel, second_channel])
+        mock_connect.return_value = mock_conn
 
         service = AsyncRabbitMQService(_make_client())
-        contexts: list[AsyncContextManager[Any]] = [
-            IteratorContext("remaining"),
-            IteratorContext("failing", fail=True),
-        ]
+        config = AsyncRabbitmqConsumerConfig(
+            queue_name="test-queue",
+            consume_timeout=0.01,
+        )
 
-        cleanup_failed = await service._close_iterator_contexts(contexts)
+        await service.consume(config)
+        await first_callbacks[0](_mock_message(delivery_tag=1))
+        await service._teardown_consume_channel("test reset")
+        await first_callbacks[0](_mock_message(delivery_tag=2))
+        assert service.health()["buffered_delivery_count"] == 0
 
-        assert cleanup_failed is True
-        assert closed == ["failing", "remaining"]
+        setup_fetch = asyncio.create_task(service.consume(config))
+        await asyncio.sleep(0)
+        await second_callbacks[0](_mock_message(delivery_tag=3))
+        result = await setup_fetch
+
+        assert [message["delivery_tag"] for message in result] == [3]
 
 
 class TestPublish:

--- a/sdks/python/tests/test_smoke.py
+++ b/sdks/python/tests/test_smoke.py
@@ -4,4 +4,4 @@ import ergon
 
 
 def test_ergon_package_is_importable() -> None:
-    assert ergon.__version__ == "0.1.9"
+    assert ergon.__version__ == "0.1.10"


### PR DESCRIPTION
## Summary
- replace per-fetch aio-pika iterator churn with one long-lived `basic.consume` registration per queue
- buffer broker-pushed deliveries behind QoS/prefetch while preserving the existing fetch/ack/nack connector contract
- rebuild cancelled consumer tags safely, add regression coverage, and release the framework as 0.1.10

## Test plan
- [x] `uv run pytest -q` (351 passed)
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv sync --dev --extra nylas && uv run pyright`
- [x] focused RabbitMQ service suite (52 passed)

Made with [Cursor](https://cursor.com)