### PR TITLE
fix(rabbitmq): harden persistent consumer bounds

### DIFF
--- a/docs/modules/3.connector.md
+++ b/docs/modules/3.connector.md
@@ -198,7 +198,7 @@ config = TaskConfig(
 
 The async connector also exposes `ack_transaction()` and `nack_transaction()` methods for manual acknowledgment via the raw AMQP message stored in `Transaction.metadata["_message"]`.
 
-The connector registers one long-lived `basic.consume` callback per queue. RabbitMQ pushes deliveries into an in-memory buffer bounded by the channel's QoS/prefetch window; `fetch_transactions_async()` waits on and drains that local buffer without repeatedly registering and cancelling broker consumers. Idle workers therefore perform no consume/cancel RPC churn, while acknowledgments provide the normal AMQP backpressure signal.
+The connector registers one long-lived `basic.consume` callback per queue. RabbitMQ pushes deliveries into an in-memory buffer bounded by each queue consumer's QoS/prefetch window; for multi-queue consumers, configure per-queue prefetch so their sum stays within the worker's total concurrency budget. `fetch_transactions_async()` waits on and drains that local buffer without repeatedly registering and cancelling broker consumers. Idle workers therefore perform no consume/cancel RPC churn, while manual acknowledgments provide AMQP backpressure. `auto_ack=True` is rejected because RabbitMQ cannot apply prefetch backpressure to auto-acknowledged deliveries.
 
 #### Lifecycle and channel cancellation
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ergon-framework-python"
-version = "0.1.10"
+version = "0.1.11"
 description = "Ergon internal task-oriented project bootstrapper"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/src/ergon/__init__.py
+++ b/sdks/python/src/ergon/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "manager",
 ]
 
-__version__ = "0.1.10"
+__version__ = "0.1.11"

--- a/sdks/python/src/ergon/connector/rabbitmq/async_service.py
+++ b/sdks/python/src/ergon/connector/rabbitmq/async_service.py
@@ -99,7 +99,9 @@ class AsyncRabbitMQService:
         # AMQP is push-based: one long-lived basic.consume registration per
         # queue feeds this local buffer. Broker QoS bounds the number of
         # unacknowledged deliveries, so fetches only drain memory.
-        self._delivery_buffer: asyncio.Queue[tuple[int, Dict[str, Any]]] = asyncio.Queue()
+        self._delivery_buffer: asyncio.Queue[tuple[int, Optional[Dict[str, Any]]]] = asyncio.Queue()
+        self._fetch_waiters = 0
+        self._closed = False
         self._consumer_setup_lock = asyncio.Lock()
         self._consumer_config_signature: Optional[str] = None
 
@@ -235,6 +237,7 @@ class AsyncRabbitMQService:
         self._consumer_epoch += 1
         self._consumer_state = "channel_dead"
         self._in_flight_message_ids.clear()
+        self._wake_pending_fetches()
         await self._close_channel_safely(channel, reason)
 
     async def _close_channel_safely(self, channel: Optional[AbstractChannel], reason: str) -> None:
@@ -265,6 +268,7 @@ class AsyncRabbitMQService:
         self._consumer_epoch += 1
         self._consumer_state = "channel_dead"
         self._in_flight_message_ids.clear()
+        self._wake_pending_fetches()
         if channel.is_closed:
             return
         try:
@@ -415,6 +419,8 @@ class AsyncRabbitMQService:
         """
         if batch_size <= 0:
             return []
+        if self._closed:
+            raise RuntimeError("RabbitMQ service is closed")
 
         self._last_poll_started_ts = time.time()
         self._consumer_state = "subscribing"
@@ -432,15 +438,22 @@ class AsyncRabbitMQService:
         buffer: List[Dict[str, Any]] = []
         try:
             self._consumer_state = "polling"
-            async with timeout_after(config.consume_timeout):
-                buffer.append(await self._next_current_delivery())
+            self._fetch_waiters += 1
+            try:
+                async with timeout_after(config.consume_timeout):
+                    first_delivery = await self._next_current_delivery()
+            finally:
+                self._fetch_waiters -= 1
+
+            if first_delivery is not None:
+                buffer.append(first_delivery)
 
             while len(buffer) < batch_size:
                 try:
                     epoch, delivery = self._delivery_buffer.get_nowait()
                 except asyncio.QueueEmpty:
                     break
-                if epoch == self._consumer_epoch:
+                if epoch == self._consumer_epoch and delivery is not None:
                     buffer.append(delivery)
         except TimeoutError:
             poll_completed = True
@@ -451,12 +464,15 @@ class AsyncRabbitMQService:
                 await self._teardown_consume_channel("consume channel observed closed after iteration")
             if poll_completed:
                 self._last_poll_completed_ts = time.time()
-                self._consumer_state = "polling"
+                if not self._closed:
+                    self._consumer_state = "polling"
 
         return buffer
 
     async def _ensure_consumers(self, config: AsyncRabbitmqConsumerConfig) -> None:
         """Declare topology and register one persistent consumer per queue."""
+        if self._closed:
+            raise RuntimeError("RabbitMQ service is closed")
         signature = config.model_dump_json()
 
         async with self._consumer_setup_lock:
@@ -500,12 +516,10 @@ class AsyncRabbitMQService:
                         *,
                         delivery_queue_name: str = queue_name,
                         delivery_epoch: int = epoch,
-                        delivery_auto_ack: bool = config.auto_ack,
                     ) -> None:
                         if delivery_epoch != self._consumer_epoch:
                             return
-                        if not delivery_auto_ack:
-                            self._in_flight_message_ids.add(id(message))
+                        self._in_flight_message_ids.add(id(message))
                         self._last_fetch_ts = time.time()
                         self._consumer_state = "delivering"
                         self._delivery_buffer.put_nowait(
@@ -555,7 +569,12 @@ class AsyncRabbitMQService:
             return True
         return set(self._active_consumer_tags.values()).issubset(consumers)
 
-    async def _next_current_delivery(self) -> Dict[str, Any]:
+    def _wake_pending_fetches(self) -> None:
+        """Wake local buffer readers after channel teardown or shutdown."""
+        for _ in range(self._fetch_waiters):
+            self._delivery_buffer.put_nowait((self._consumer_epoch, None))
+
+    async def _next_current_delivery(self) -> Optional[Dict[str, Any]]:
         """Discard stale-epoch entries and return the next live delivery."""
         while True:
             epoch, delivery = await self._delivery_buffer.get()
@@ -718,6 +737,8 @@ class AsyncRabbitMQService:
     # ---------- Lifecycle ----------
 
     async def close(self) -> None:
+        self._closed = True
+        self._consumer_state = "closing"
         await self._teardown_consume_channel("service close")
 
         publish_channel = self._publish_channel

--- a/sdks/python/src/ergon/connector/rabbitmq/models.py
+++ b/sdks/python/src/ergon/connector/rabbitmq/models.py
@@ -134,7 +134,10 @@ class AsyncRabbitmqConsumerConfig(BaseModel):
         ),
     )
     durable: bool = Field(default=True, description="Durable exchange and queue declarations")
-    auto_ack: bool = Field(default=False, description="Automatically acknowledge messages on delivery")
+    auto_ack: bool = Field(
+        default=False,
+        description="Must remain false so broker prefetch provides bounded delivery backpressure",
+    )
     consume_timeout: float = Field(default=2.0, description="Max seconds to wait per fetch call")
     queue_arguments: dict[str, Any] = Field(
         default_factory=dict,
@@ -151,6 +154,10 @@ class AsyncRabbitmqConsumerConfig(BaseModel):
     def validate_subscriptions(self) -> "AsyncRabbitmqConsumerConfig":
         if self.queue_name is None and not self.subscriptions:
             raise ValueError("At least one queue_name or subscription is required")
+        if self.auto_ack:
+            raise ValueError(
+                "Async RabbitMQ consumers require manual acknowledgments; auto_ack=True bypasses prefetch backpressure"
+            )
 
         queue_names = [subscription.queue_name for subscription in self.subscriptions]
         if self.queue_name is not None:

--- a/sdks/python/tests/connector/rabbitmq/test_async_service.py
+++ b/sdks/python/tests/connector/rabbitmq/test_async_service.py
@@ -307,24 +307,12 @@ class TestConsume:
         _, consume_kwargs = mock_queue.consume.call_args
         assert consume_kwargs == {"no_ack": False, "robust": False}
 
-    @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
-    async def test_auto_ack_delivery_is_not_tracked_as_in_flight(self, mock_connect):
-        mock_queue, _callbacks = _mock_consumer_queue(messages=[_mock_message()])
-        mock_channel = _mock_channel()
-        mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
-        mock_conn = AsyncMock()
-        mock_conn.is_closed = False
-        mock_conn.channel = AsyncMock(return_value=mock_channel)
-        mock_connect.return_value = mock_conn
-
-        service = AsyncRabbitMQService(_make_client())
-        config = AsyncRabbitmqConsumerConfig(
-            queue_name="test-queue",
-            auto_ack=True,
-        )
-
-        assert len(await service.consume(config)) == 1
-        assert service.health()["in_flight_count"] == 0
+    def test_auto_ack_is_rejected_without_broker_backpressure(self):
+        with pytest.raises(ValueError, match="bypasses prefetch backpressure"):
+            AsyncRabbitmqConsumerConfig(
+                queue_name="test-queue",
+                auto_ack=True,
+            )
 
     @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
     async def test_consume_returns_first_delivery_without_waiting_to_fill_batch(self, mock_connect):
@@ -833,6 +821,34 @@ class TestClose:
         assert service._connection is None
         assert service._consume_channel is None
         assert service._publish_channel is None
+
+    @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
+    async def test_close_wakes_pending_fetch_without_overwriting_closed_state(self, mock_connect):
+        mock_queue, _callbacks = _mock_consumer_queue()
+        mock_channel = _mock_channel()
+        mock_channel.declare_queue = AsyncMock(return_value=mock_queue)
+        mock_conn = AsyncMock()
+        mock_conn.is_closed = False
+        mock_conn.channel = AsyncMock(return_value=mock_channel)
+        mock_conn.close = AsyncMock()
+        mock_connect.return_value = mock_conn
+
+        service = AsyncRabbitMQService(_make_client())
+        config = AsyncRabbitmqConsumerConfig(
+            queue_name="test-queue",
+            consume_timeout=30,
+        )
+        pending_fetch = asyncio.create_task(service.consume(config))
+        for _ in range(10):
+            if service._fetch_waiters:
+                break
+            await asyncio.sleep(0)
+
+        await service.close()
+        result = await asyncio.wait_for(pending_fetch, timeout=0.5)
+
+        assert result == []
+        assert service.health()["state"] == "closed"
 
     @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
     async def test_close_closes_both_channels(self, mock_connect):

--- a/sdks/python/tests/test_smoke.py
+++ b/sdks/python/tests/test_smoke.py
@@ -4,4 +4,4 @@ import ergon
 
 
 def test_ergon_package_is_importable() -> None:
-    assert ergon.__version__ == "0.1.10"
+    assert ergon.__version__ == "0.1.11"


### PR DESCRIPTION
## Summary
- require manual acknowledgments so RabbitMQ prefetch keeps persistent-consumer delivery memory bounded
- wake pending fetches immediately during channel teardown and service shutdown
- document per-queue prefetch semantics for multi-queue consumers
- bump the Python SDK version to `0.1.11`

Follow-up to #66.

## Test plan
- [x] `uv run pytest -q` (354 passed)
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`

Made with [Cursor](https://cursor.com)