### PR TITLE
feat(packaging): make bundled connectors optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: sdks/python
-        run: uv sync --dev
+        run: uv sync --dev --all-extras
 
       - name: Ruff Lint (no autofix)
         working-directory: sdks/python
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: sdks/python
-        run: uv sync --dev --extra nylas
+        run: uv sync --dev --all-extras
 
       - name: Pyright
         working-directory: sdks/python
@@ -76,8 +76,55 @@ jobs:
 
       - name: Install dependencies
         working-directory: sdks/python
-        run: uv sync --dev
+        run: uv sync --dev --all-extras
 
       - name: Pytest
         working-directory: sdks/python
         run: uv run pytest -v
+
+  minimal-install:
+    name: Minimal install
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install framework without connector extras
+        working-directory: sdks/python
+        run: |
+          uv venv --python 3.10 .venv-minimal
+          uv pip install --python .venv-minimal/bin/python .
+
+      - name: Verify core import and optional dependency error
+        working-directory: sdks/python
+        run: |
+          .venv-minimal/bin/python - <<'PY'
+          import sys
+
+          import ergon
+          from ergon.connector import Connector, Transaction
+
+          assert Connector is not None
+          assert Transaction is not None
+          assert "aio_pika" not in sys.modules
+          assert "asyncpg" not in sys.modules
+          assert "boto3" not in sys.modules
+          assert "httpx" not in sys.modules
+          assert "nylas" not in sys.modules
+          assert "openpyxl" not in sys.modules
+          assert "pika" not in sys.modules
+          assert "requests" not in sys.modules
+
+          try:
+              from ergon.connector import RabbitMQConnector
+          except ImportError as exc:
+              assert "ergon-framework-python[rabbitmq]" in str(exc)
+          else:
+              raise AssertionError("RabbitMQConnector imported without its optional extra")
+          PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
 
       - name: Install framework without connector extras
         working-directory: sdks/python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish:
+    name: Build & publish to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Verify tag matches package version
+        run: |
+          PACKAGE_VERSION=$(awk -F'"' '/^version = / { print $2; exit }' sdks/python/pyproject.toml)
+          test "${GITHUB_REF_NAME}" = "v${PACKAGE_VERSION}"
+
+      - name: Build sdist and wheel
+        working-directory: sdks/python
+        run: uv build
+
+      - name: Publish to PyPI
+        working-directory: sdks/python
+        run: uv publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
 
       - name: Verify tag matches package version
         run: |

--- a/README.md
+++ b/README.md
@@ -22,11 +22,14 @@ Ergon is a language-agnostic framework specification with official SDK implement
 
 ### Quick Install (Python)
 
-Ergon is not yet published to PyPI. Clone the repository and install as a local dependency:
+```bash
+pip install ergon-framework-python
+```
+
+Connector integrations are optional. Install only the ones your application uses:
 
 ```bash
-git clone https://github.com/your-org/ergon-framework.git
-pip install -e /path/to/ergon-framework/sdks/python
+pip install 'ergon-framework-python[rabbitmq,postgres]'
 ```
 
 ### Running Tasks

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -14,6 +14,18 @@
 pip install ergon-framework-python
 ```
 
+Connector integrations are optional extras, so a core installation does not
+pull in client libraries that your application does not use:
+
+```bash
+pip install 'ergon-framework-python[rabbitmq]'
+pip install 'ergon-framework-python[sqs,postgres]'
+pip install 'ergon-framework-python[all]'
+```
+
+Available extras are `rabbitmq`, `sqs`, `postgres`, `pipefy`, `excel`,
+`ergon-platform`, and `nylas`.
+
 For local development, install in editable mode:
 
 ```bash

--- a/sdks/python/docs/getting-started.md
+++ b/sdks/python/docs/getting-started.md
@@ -6,15 +6,23 @@ This guide walks you through setting up a project with the Ergon Python SDK—fr
 
 ## Installation
 
-Ergon is not yet published to PyPI. To use the framework, clone the repository and install it as a local dependency.
-
-### Clone the Repository
+Install the core framework from PyPI:
 
 ```bash
-git clone https://github.com/your-org/ergon-framework.git
+pip install ergon-framework-python
 ```
 
-### Install as a Path Dependency
+Connector client libraries are optional. Select only the integrations the application uses:
+
+```bash
+pip install 'ergon-framework-python[rabbitmq,postgres]'
+```
+
+Available connector extras are `rabbitmq`, `sqs`, `postgres`, `pipefy`, `excel`,
+`ergon-platform`, and `nylas`. Use `ergon-framework-python[all]` for every bundled
+connector.
+
+### Local Development
 
 Add Ergon to your project's `pyproject.toml`:
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ergon-framework-python"
-version = "0.1.11"
+version = "0.2.0"
 description = "Ergon internal task-oriented project bootstrapper"
 readme = "README.md"
 license = "MIT"
@@ -18,28 +18,48 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
+    "async-timeout>=5.0.1",
+    "more-itertools>=10.8.0",
+    "opentelemetry-api>=1.38.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.38.0",
+    "opentelemetry-sdk>=1.38.0",
+    "pydantic>=2.12.4",
+    "python-dotenv>=1.2.1",
+    "python-json-logger>=4.0.0",
+]
+
+[project.optional-dependencies]
+all = [
     "aio-pika>=9.0.0",
     "aiobotocore>=2.13.0",
-    "async-timeout>=5.0.1",
     "asyncpg>=0.29.0",
     "boto3>=1.35.0",
     "ergon-platform-sdk>=0.1.0",
     "httpx>=0.28.0",
-    "more-itertools>=10.8.0",
+    "nylas>=6.0.0",
     "openpyxl>=3.1.5",
-    "opentelemetry-api>=1.38.0",
-    "opentelemetry-exporter-otlp-proto-grpc>=1.38.0",
-    "opentelemetry-sdk>=1.38.0",
     "pika>=1.3.0",
-    "pydantic>=2.12.4",
-    "python-dotenv>=1.2.1",
-    "python-json-logger>=4.0.0",
     "requests>=2.32.5",
 ]
-
-[project.optional-dependencies]
+"ergon-platform" = [
+    "ergon-platform-sdk>=0.1.0",
+    "httpx>=0.28.0",
+]
+excel = ["openpyxl>=3.1.5"]
 nylas = ["nylas>=6.0.0"]
-ergon_platform = []
+pipefy = [
+    "httpx>=0.28.0",
+    "requests>=2.32.5",
+]
+postgres = ["asyncpg>=0.29.0"]
+rabbitmq = [
+    "aio-pika>=9.0.0",
+    "pika>=1.3.0",
+]
+sqs = [
+    "aiobotocore>=2.13.0",
+    "boto3>=1.35.0",
+]
 
 [dependency-groups]
 dev = [

--- a/sdks/python/src/ergon/__init__.py
+++ b/sdks/python/src/ergon/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "manager",
 ]
 
-__version__ = "0.1.11"
+__version__ = "0.2.0"

--- a/sdks/python/src/ergon/connector/__init__.py
+++ b/sdks/python/src/ergon/connector/__init__.py
@@ -1,3 +1,4 @@
+from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
 from ._lazy import exported_names, load_export
@@ -63,6 +64,16 @@ if TYPE_CHECKING:
         SQSService,
     )
 
+_CONNECTOR_SUBPACKAGES = (
+    "ergon_platform",
+    "excel",
+    "nylas",
+    "pipefy",
+    "postgres",
+    "rabbitmq",
+    "sqs",
+)
+
 _LAZY_EXPORTS = {
     "AckActionConfig": "nylas",
     "AsyncErgonPlatformConnector": "ergon_platform",
@@ -118,6 +129,10 @@ _LAZY_EXPORTS = {
 
 
 def __getattr__(name: str) -> Any:
+    if name in _CONNECTOR_SUBPACKAGES:
+        module = import_module(f".{name}", __name__)
+        globals()[name] = module
+        return module
     return load_export(
         name=name,
         package=__name__,
@@ -127,7 +142,7 @@ def __getattr__(name: str) -> Any:
 
 
 def __dir__() -> list[str]:
-    return exported_names(globals(), _LAZY_EXPORTS)
+    return sorted(set(exported_names(globals(), _LAZY_EXPORTS)) | set(_CONNECTOR_SUBPACKAGES))
 
 
 __all__ = [

--- a/sdks/python/src/ergon/connector/__init__.py
+++ b/sdks/python/src/ergon/connector/__init__.py
@@ -1,62 +1,134 @@
+from typing import TYPE_CHECKING, Any
+
+from ._lazy import exported_names, load_export
 from .connector import AsyncConnector, Connector, ConnectorConfig
-from .ergon_platform import (
-    AsyncErgonPlatformConnector,
-    CreateItemInput,
-    ErgonPlatformClient,
-    ErgonPlatformConnector,
-    ErgonPlatformConsumerConfig,
-    ErgonPlatformProducerConfig,
-)
-from .excel import ExcelConnector, ExcelFetchConfig, ExcelRow, ExcelService
-from .nylas import (
-    AckActionConfig,
-    AsyncNylasAuthService,
-    AsyncNylasConnector,
-    AsyncNylasService,
-    AuthUrlConfig,
-    CodeExchangeInput,
-    GrantAuthResult,
-    MessageQueryFilter,
-    NylasAuthClient,
-    NylasAuthService,
-    NylasClient,
-    NylasConnector,
-    NylasConsumerConfig,
-    NylasProducerConfig,
-    NylasService,
-    SendMessageInput,
-)
-from .postgres import (
-    AsyncPostgresConnector,
-    AsyncPostgresService,
-    PostgresClient,
-    PostgresConsumerConfig,
-    PostgresProducerConfig,
-)
-from .rabbitmq import (
-    AsyncRabbitmqClient,
-    AsyncRabbitMQConnector,
-    AsyncRabbitmqConsumerConfig,
-    AsyncRabbitmqExchangeBinding,
-    AsyncRabbitmqProducerConfig,
-    AsyncRabbitmqQueueSubscription,
-    AsyncRabbitMQService,
-    RabbitmqClient,
-    RabbitMQConnector,
-    RabbitmqConsumerMessage,
-    RabbitmqProducerMessage,
-    RabbitMQService,
-)
-from .sqs import (
-    AsyncSQSConnector,
-    AsyncSQSService,
-    SQSClient,
-    SQSConnector,
-    SQSConsumerConfig,
-    SQSProducerConfig,
-    SQSService,
-)
 from .transaction import Transaction
+
+if TYPE_CHECKING:
+    from .ergon_platform import (
+        AsyncErgonPlatformConnector,
+        CreateItemInput,
+        ErgonPlatformClient,
+        ErgonPlatformConnector,
+        ErgonPlatformConsumerConfig,
+        ErgonPlatformProducerConfig,
+    )
+    from .excel import ExcelConnector, ExcelFetchConfig, ExcelRow, ExcelService
+    from .nylas import (
+        AckActionConfig,
+        AsyncNylasAuthService,
+        AsyncNylasConnector,
+        AsyncNylasService,
+        AuthUrlConfig,
+        CodeExchangeInput,
+        GrantAuthResult,
+        MessageQueryFilter,
+        NylasAuthClient,
+        NylasAuthService,
+        NylasClient,
+        NylasConnector,
+        NylasConsumerConfig,
+        NylasProducerConfig,
+        NylasService,
+        SendMessageInput,
+    )
+    from .postgres import (
+        AsyncPostgresConnector,
+        AsyncPostgresService,
+        PostgresClient,
+        PostgresConsumerConfig,
+        PostgresProducerConfig,
+    )
+    from .rabbitmq import (
+        AsyncRabbitmqClient,
+        AsyncRabbitMQConnector,
+        AsyncRabbitmqConsumerConfig,
+        AsyncRabbitmqExchangeBinding,
+        AsyncRabbitmqProducerConfig,
+        AsyncRabbitmqQueueSubscription,
+        AsyncRabbitMQService,
+        RabbitmqClient,
+        RabbitMQConnector,
+        RabbitmqConsumerMessage,
+        RabbitmqProducerMessage,
+        RabbitMQService,
+    )
+    from .sqs import (
+        AsyncSQSConnector,
+        AsyncSQSService,
+        SQSClient,
+        SQSConnector,
+        SQSConsumerConfig,
+        SQSProducerConfig,
+        SQSService,
+    )
+
+_LAZY_EXPORTS = {
+    "AckActionConfig": "nylas",
+    "AsyncErgonPlatformConnector": "ergon_platform",
+    "AsyncNylasAuthService": "nylas",
+    "AsyncNylasConnector": "nylas",
+    "AsyncNylasService": "nylas",
+    "AsyncPostgresConnector": "postgres",
+    "AsyncPostgresService": "postgres",
+    "AsyncRabbitMQConnector": "rabbitmq",
+    "AsyncRabbitMQService": "rabbitmq",
+    "AsyncRabbitmqClient": "rabbitmq",
+    "AsyncRabbitmqConsumerConfig": "rabbitmq",
+    "AsyncRabbitmqExchangeBinding": "rabbitmq",
+    "AsyncRabbitmqProducerConfig": "rabbitmq",
+    "AsyncRabbitmqQueueSubscription": "rabbitmq",
+    "AsyncSQSConnector": "sqs",
+    "AsyncSQSService": "sqs",
+    "AuthUrlConfig": "nylas",
+    "CodeExchangeInput": "nylas",
+    "CreateItemInput": "ergon_platform",
+    "ErgonPlatformClient": "ergon_platform",
+    "ErgonPlatformConnector": "ergon_platform",
+    "ErgonPlatformConsumerConfig": "ergon_platform",
+    "ErgonPlatformProducerConfig": "ergon_platform",
+    "ExcelConnector": "excel",
+    "ExcelFetchConfig": "excel",
+    "ExcelRow": "excel",
+    "ExcelService": "excel",
+    "GrantAuthResult": "nylas",
+    "MessageQueryFilter": "nylas",
+    "NylasAuthClient": "nylas",
+    "NylasAuthService": "nylas",
+    "NylasClient": "nylas",
+    "NylasConnector": "nylas",
+    "NylasConsumerConfig": "nylas",
+    "NylasProducerConfig": "nylas",
+    "NylasService": "nylas",
+    "PostgresClient": "postgres",
+    "PostgresConsumerConfig": "postgres",
+    "PostgresProducerConfig": "postgres",
+    "RabbitMQConnector": "rabbitmq",
+    "RabbitMQService": "rabbitmq",
+    "RabbitmqClient": "rabbitmq",
+    "RabbitmqConsumerMessage": "rabbitmq",
+    "RabbitmqProducerMessage": "rabbitmq",
+    "SQSClient": "sqs",
+    "SQSConnector": "sqs",
+    "SQSConsumerConfig": "sqs",
+    "SQSProducerConfig": "sqs",
+    "SQSService": "sqs",
+    "SendMessageInput": "nylas",
+}
+
+
+def __getattr__(name: str) -> Any:
+    return load_export(
+        name=name,
+        package=__name__,
+        exports=_LAZY_EXPORTS,
+        namespace=globals(),
+    )
+
+
+def __dir__() -> list[str]:
+    return exported_names(globals(), _LAZY_EXPORTS)
+
 
 __all__ = [
     "AckActionConfig",

--- a/sdks/python/src/ergon/connector/_lazy.py
+++ b/sdks/python/src/ergon/connector/_lazy.py
@@ -1,0 +1,51 @@
+"""Helpers for loading connector implementations only when requested."""
+
+from importlib import import_module
+from typing import Any, Mapping, MutableMapping, Sequence
+
+
+def load_export(
+    *,
+    name: str,
+    package: str,
+    exports: Mapping[str, str],
+    namespace: MutableMapping[str, Any],
+) -> Any:
+    """Load and cache one lazily exported attribute."""
+    module_name = exports.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {package!r} has no attribute {name!r}")
+
+    module = import_module(f".{module_name}", package)
+    value = getattr(module, name)
+    namespace[name] = value
+    return value
+
+
+def load_optional_export(
+    *,
+    name: str,
+    package: str,
+    exports: Mapping[str, str],
+    namespace: MutableMapping[str, Any],
+    extra: str,
+    dependencies: Sequence[str],
+) -> Any:
+    """Load a connector export and explain how to install a missing extra."""
+    try:
+        return load_export(name=name, package=package, exports=exports, namespace=namespace)
+    except ModuleNotFoundError as exc:
+        missing_module = exc.name or ""
+        if not any(
+            missing_module == dependency or missing_module.startswith(f"{dependency}.") for dependency in dependencies
+        ):
+            raise
+        raise ImportError(
+            f"The {extra!r} connector dependencies are not installed. "
+            f"Install them with: pip install 'ergon-framework-python[{extra}]'"
+        ) from exc
+
+
+def exported_names(namespace: Mapping[str, Any], exports: Mapping[str, str]) -> list[str]:
+    """Return module names including lazy exports for interactive discovery."""
+    return sorted(set(namespace) | set(exports))

--- a/sdks/python/src/ergon/connector/ergon_platform/__init__.py
+++ b/sdks/python/src/ergon/connector/ergon_platform/__init__.py
@@ -1,11 +1,37 @@
-from .async_connector import AsyncErgonPlatformConnector
-from .connector import ErgonPlatformConnector
+from typing import TYPE_CHECKING, Any
+
+from .._lazy import exported_names, load_optional_export
 from .models import (
     CreateItemInput,
     ErgonPlatformClient,
     ErgonPlatformConsumerConfig,
     ErgonPlatformProducerConfig,
 )
+
+if TYPE_CHECKING:
+    from .async_connector import AsyncErgonPlatformConnector
+    from .connector import ErgonPlatformConnector
+
+_LAZY_EXPORTS = {
+    "AsyncErgonPlatformConnector": "async_connector",
+    "ErgonPlatformConnector": "connector",
+}
+
+
+def __getattr__(name: str) -> Any:
+    return load_optional_export(
+        name=name,
+        package=__name__,
+        exports=_LAZY_EXPORTS,
+        namespace=globals(),
+        extra="ergon-platform",
+        dependencies=("ergon_platform", "httpx"),
+    )
+
+
+def __dir__() -> list[str]:
+    return exported_names(globals(), _LAZY_EXPORTS)
+
 
 __all__ = [
     "AsyncErgonPlatformConnector",

--- a/sdks/python/src/ergon/connector/ergon_platform/_client.py
+++ b/sdks/python/src/ergon/connector/ergon_platform/_client.py
@@ -1,6 +1,9 @@
 from .models import ErgonPlatformClient
 
-_ERGON_PLATFORM_IMPORT_ERROR = "Install the ergon-platform-sdk package in the same environment"
+_ERGON_PLATFORM_IMPORT_ERROR = (
+    "The 'ergon-platform' connector dependencies are not installed. "
+    "Install them with: pip install 'ergon-framework-python[ergon-platform]'"
+)
 
 
 def _get_ergon_client():

--- a/sdks/python/src/ergon/connector/excel/__init__.py
+++ b/sdks/python/src/ergon/connector/excel/__init__.py
@@ -6,9 +6,35 @@ Provides transaction-based access to Excel files with support for:
 - Sharding for parallel processing
 """
 
-from .connector import ExcelConnector
+from typing import TYPE_CHECKING, Any
+
+from .._lazy import exported_names, load_optional_export
 from .models import ExcelFetchConfig, ExcelRow
-from .service import ExcelService
+
+if TYPE_CHECKING:
+    from .connector import ExcelConnector
+    from .service import ExcelService
+
+_LAZY_EXPORTS = {
+    "ExcelConnector": "connector",
+    "ExcelService": "service",
+}
+
+
+def __getattr__(name: str) -> Any:
+    return load_optional_export(
+        name=name,
+        package=__name__,
+        exports=_LAZY_EXPORTS,
+        namespace=globals(),
+        extra="excel",
+        dependencies=("openpyxl",),
+    )
+
+
+def __dir__() -> list[str]:
+    return exported_names(globals(), _LAZY_EXPORTS)
+
 
 __all__ = [
     "ExcelConnector",

--- a/sdks/python/src/ergon/connector/nylas/__init__.py
+++ b/sdks/python/src/ergon/connector/nylas/__init__.py
@@ -1,8 +1,6 @@
-from .async_auth_service import AsyncNylasAuthService
-from .async_connector import AsyncNylasConnector
-from .async_service import AsyncNylasService
-from .auth_service import NylasAuthService
-from .connector import NylasConnector
+from typing import TYPE_CHECKING, Any
+
+from .._lazy import exported_names, load_optional_export
 from .models import (
     AckActionConfig,
     AttachmentInput,
@@ -19,7 +17,39 @@ from .models import (
     NylasProducerConfig,
     SendMessageInput,
 )
-from .service import NylasService
+
+if TYPE_CHECKING:
+    from .async_auth_service import AsyncNylasAuthService
+    from .async_connector import AsyncNylasConnector
+    from .async_service import AsyncNylasService
+    from .auth_service import NylasAuthService
+    from .connector import NylasConnector
+    from .service import NylasService
+
+_LAZY_EXPORTS = {
+    "AsyncNylasAuthService": "async_auth_service",
+    "AsyncNylasConnector": "async_connector",
+    "AsyncNylasService": "async_service",
+    "NylasAuthService": "auth_service",
+    "NylasConnector": "connector",
+    "NylasService": "service",
+}
+
+
+def __getattr__(name: str) -> Any:
+    return load_optional_export(
+        name=name,
+        package=__name__,
+        exports=_LAZY_EXPORTS,
+        namespace=globals(),
+        extra="nylas",
+        dependencies=("nylas",),
+    )
+
+
+def __dir__() -> list[str]:
+    return exported_names(globals(), _LAZY_EXPORTS)
+
 
 __all__ = [
     "AckActionConfig",

--- a/sdks/python/src/ergon/connector/pipefy/__init__.py
+++ b/sdks/python/src/ergon/connector/pipefy/__init__.py
@@ -1,13 +1,41 @@
-from .async_connector import AsyncPipefyConnector
-from .async_service import AsyncPipefyService
-from .connector import PipefyConnector
+from typing import TYPE_CHECKING, Any
+
+from .._lazy import exported_names, load_optional_export
 from .models import (
     CreateCardInput,
     FieldFilter,
     FieldFilterOperator,
     PipefyClient,
 )
-from .service import PipefyService
+
+if TYPE_CHECKING:
+    from .async_connector import AsyncPipefyConnector
+    from .async_service import AsyncPipefyService
+    from .connector import PipefyConnector
+    from .service import PipefyService
+
+_LAZY_EXPORTS = {
+    "AsyncPipefyConnector": "async_connector",
+    "AsyncPipefyService": "async_service",
+    "PipefyConnector": "connector",
+    "PipefyService": "service",
+}
+
+
+def __getattr__(name: str) -> Any:
+    return load_optional_export(
+        name=name,
+        package=__name__,
+        exports=_LAZY_EXPORTS,
+        namespace=globals(),
+        extra="pipefy",
+        dependencies=("httpx", "requests"),
+    )
+
+
+def __dir__() -> list[str]:
+    return exported_names(globals(), _LAZY_EXPORTS)
+
 
 __all__ = [
     "AsyncPipefyConnector",

--- a/sdks/python/src/ergon/connector/postgres/__init__.py
+++ b/sdks/python/src/ergon/connector/postgres/__init__.py
@@ -1,6 +1,32 @@
-from .async_connector import AsyncPostgresConnector
-from .async_service import AsyncPostgresService
+from typing import TYPE_CHECKING, Any
+
+from .._lazy import exported_names, load_optional_export
 from .models import PostgresClient, PostgresConsumerConfig, PostgresProducerConfig
+
+if TYPE_CHECKING:
+    from .async_connector import AsyncPostgresConnector
+    from .async_service import AsyncPostgresService
+
+_LAZY_EXPORTS = {
+    "AsyncPostgresConnector": "async_connector",
+    "AsyncPostgresService": "async_service",
+}
+
+
+def __getattr__(name: str) -> Any:
+    return load_optional_export(
+        name=name,
+        package=__name__,
+        exports=_LAZY_EXPORTS,
+        namespace=globals(),
+        extra="postgres",
+        dependencies=("asyncpg",),
+    )
+
+
+def __dir__() -> list[str]:
+    return exported_names(globals(), _LAZY_EXPORTS)
+
 
 __all__ = [
     "AsyncPostgresConnector",

--- a/sdks/python/src/ergon/connector/rabbitmq/__init__.py
+++ b/sdks/python/src/ergon/connector/rabbitmq/__init__.py
@@ -1,6 +1,6 @@
-from .async_connector import AsyncRabbitMQConnector
-from .async_service import AsyncRabbitMQService
-from .connector import RabbitMQConnector
+from typing import TYPE_CHECKING, Any
+
+from .._lazy import exported_names, load_optional_export
 from .models import (
     AsyncRabbitmqClient,
     AsyncRabbitmqConsumerConfig,
@@ -11,7 +11,35 @@ from .models import (
     RabbitmqConsumerMessage,
     RabbitmqProducerMessage,
 )
-from .service import RabbitMQService
+
+if TYPE_CHECKING:
+    from .async_connector import AsyncRabbitMQConnector
+    from .async_service import AsyncRabbitMQService
+    from .connector import RabbitMQConnector
+    from .service import RabbitMQService
+
+_LAZY_EXPORTS = {
+    "AsyncRabbitMQConnector": "async_connector",
+    "AsyncRabbitMQService": "async_service",
+    "RabbitMQConnector": "connector",
+    "RabbitMQService": "service",
+}
+
+
+def __getattr__(name: str) -> Any:
+    return load_optional_export(
+        name=name,
+        package=__name__,
+        exports=_LAZY_EXPORTS,
+        namespace=globals(),
+        extra="rabbitmq",
+        dependencies=("aio_pika", "aiormq", "pika"),
+    )
+
+
+def __dir__() -> list[str]:
+    return exported_names(globals(), _LAZY_EXPORTS)
+
 
 __all__ = [
     "AsyncRabbitMQConnector",

--- a/sdks/python/src/ergon/connector/sqs/__init__.py
+++ b/sdks/python/src/ergon/connector/sqs/__init__.py
@@ -1,8 +1,36 @@
-from .async_connector import AsyncSQSConnector
-from .async_service import AsyncSQSService
-from .connector import SQSConnector
+from typing import TYPE_CHECKING, Any
+
+from .._lazy import exported_names, load_optional_export
 from .models import SQSClient, SQSConsumerConfig, SQSProducerConfig
-from .service import SQSService
+
+if TYPE_CHECKING:
+    from .async_connector import AsyncSQSConnector
+    from .async_service import AsyncSQSService
+    from .connector import SQSConnector
+    from .service import SQSService
+
+_LAZY_EXPORTS = {
+    "AsyncSQSConnector": "async_connector",
+    "AsyncSQSService": "async_service",
+    "SQSConnector": "connector",
+    "SQSService": "service",
+}
+
+
+def __getattr__(name: str) -> Any:
+    return load_optional_export(
+        name=name,
+        package=__name__,
+        exports=_LAZY_EXPORTS,
+        namespace=globals(),
+        extra="sqs",
+        dependencies=("aiobotocore", "boto3", "botocore"),
+    )
+
+
+def __dir__() -> list[str]:
+    return exported_names(globals(), _LAZY_EXPORTS)
+
 
 __all__ = [
     "AsyncSQSConnector",

--- a/sdks/python/tests/test_optional_connectors.py
+++ b/sdks/python/tests/test_optional_connectors.py
@@ -1,0 +1,76 @@
+"""Regression tests for connector dependency isolation."""
+
+import subprocess
+import sys
+import textwrap
+
+
+def _run_isolated(script: str) -> None:
+    subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_core_import_does_not_load_connector_clients() -> None:
+    _run_isolated(
+        """
+        import sys
+
+        import ergon
+        from ergon.connector import Connector, Transaction
+
+        assert Connector is not None
+        assert Transaction is not None
+        assert "aio_pika" not in sys.modules
+        assert "asyncpg" not in sys.modules
+        assert "boto3" not in sys.modules
+        assert "httpx" not in sys.modules
+        assert "nylas" not in sys.modules
+        assert "openpyxl" not in sys.modules
+        assert "pika" not in sys.modules
+        assert "requests" not in sys.modules
+        """
+    )
+
+
+def test_connector_models_remain_available_without_loading_client() -> None:
+    _run_isolated(
+        """
+        import sys
+
+        from ergon.connector import AsyncRabbitmqConsumerConfig
+
+        assert AsyncRabbitmqConsumerConfig is not None
+        assert "aio_pika" not in sys.modules
+        assert "pika" not in sys.modules
+        """
+    )
+
+
+def test_missing_connector_extra_has_actionable_error() -> None:
+    _run_isolated(
+        """
+        import importlib.abc
+        import sys
+
+
+        class BlockPika(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path, target=None):
+                if fullname == "pika" or fullname.startswith("pika."):
+                    raise ModuleNotFoundError("blocked for test", name=fullname)
+                return None
+
+
+        sys.meta_path.insert(0, BlockPika())
+
+        try:
+            from ergon.connector import RabbitMQConnector
+        except ImportError as exc:
+            assert "ergon-framework-python[rabbitmq]" in str(exc)
+        else:
+            raise AssertionError("RabbitMQConnector imported without the blocked dependency")
+        """
+    )

--- a/sdks/python/tests/test_optional_connectors.py
+++ b/sdks/python/tests/test_optional_connectors.py
@@ -6,12 +6,12 @@ import textwrap
 
 
 def _run_isolated(script: str) -> None:
-    subprocess.run(
+    result = subprocess.run(
         [sys.executable, "-c", textwrap.dedent(script)],
-        check=True,
         text=True,
         capture_output=True,
     )
+    assert result.returncode == 0, f"isolated script failed:\n{result.stdout}\n{result.stderr}"
 
 
 def test_core_import_does_not_load_connector_clients() -> None:
@@ -46,6 +46,18 @@ def test_connector_models_remain_available_without_loading_client() -> None:
         assert AsyncRabbitmqConsumerConfig is not None
         assert "aio_pika" not in sys.modules
         assert "pika" not in sys.modules
+        """
+    )
+
+
+def test_subpackages_are_reachable_as_module_attributes() -> None:
+    _run_isolated(
+        """
+        import ergon.connector
+
+        assert ergon.connector.rabbitmq.RabbitMQConnector is not None
+        assert ergon.connector.postgres.PostgresClient is not None
+        assert "rabbitmq" in dir(ergon.connector)
         """
     )
 

--- a/sdks/python/tests/test_smoke.py
+++ b/sdks/python/tests/test_smoke.py
@@ -4,4 +4,4 @@ import ergon
 
 
 def test_ergon_package_is_importable() -> None:
-    assert ergon.__version__ == "0.1.11"
+    assert ergon.__version__ == "0.2.0"


### PR DESCRIPTION
## Summary
- move RabbitMQ, SQS, Postgres, Pipefy, Excel, Ergon Platform, and Nylas client libraries behind installable connector extras
- preserve existing top-level connector imports through lazy exports and provide actionable missing-extra errors
- add minimal-install CI coverage to prevent connector dependencies leaking back into the core package
- add tag-triggered PyPI trusted publishing and verify release tags match package metadata
- release the breaking dependency contract as `0.2.0`

## Installation
```bash
pip install ergon-framework-python
pip install 'ergon-framework-python[rabbitmq,postgres]'
pip install 'ergon-framework-python[all]'
```

## Test plan
- [x] `uv run pytest -q` (357 passed)
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv build`
- [x] clean Python 3.10 environment installs the core package without connector clients
- [x] missing connector extra reports the exact install command

Made with [Cursor](https://cursor.com)