### PR TITLE
fix(nylas): preserve aliased query filters and add ack delete

### DIFF
--- a/sdks/python/examples/nylas/README.md
+++ b/sdks/python/examples/nylas/README.md
@@ -44,7 +44,7 @@ Filtros mais usados em `NylasConsumerConfig`:
 - `has_attachment=True` — mensagens com anexos
 - `in_="<FOLDER_ID>"` — pasta ou label (use `service.list_folders()` para descobrir IDs)
 - `download_attachments=True` — baixa bytes dos anexos no fetch
-- `ack_config=AckActionConfig(mark_as_read=True, move_to_folder_id="...")` — ações pós-processamento; use `delete=True` para hard-delete no ack
+- `ack_config=AckActionConfig(mark_as_read=True, move_to_folder_id="...")` — ações pós-processamento; use `delete=True` para hard-delete no ack de mensagens (habilite **Enable hard delete** no Nylas Dashboard)
 
 Envio via `NylasProducerConfig(send_mode="send")` ou `"draft"`. O framework **não** faz ack automático para Nylas — chame `ack_transaction` em `handle_process_success`.
 

--- a/sdks/python/examples/nylas/README.md
+++ b/sdks/python/examples/nylas/README.md
@@ -44,7 +44,7 @@ Filtros mais usados em `NylasConsumerConfig`:
 - `has_attachment=True` — mensagens com anexos
 - `in_="<FOLDER_ID>"` — pasta ou label (use `service.list_folders()` para descobrir IDs)
 - `download_attachments=True` — baixa bytes dos anexos no fetch
-- `ack_config=AckActionConfig(mark_as_read=True, move_to_folder_id="...")` — ações pós-processamento
+- `ack_config=AckActionConfig(mark_as_read=True, move_to_folder_id="...")` — ações pós-processamento; use `delete=True` para hard-delete no ack
 
 Envio via `NylasProducerConfig(send_mode="send")` ou `"draft"`. O framework **não** faz ack automático para Nylas — chame `ack_transaction` em `handle_process_success`.
 

--- a/sdks/python/src/ergon/connector/nylas/README.md
+++ b/sdks/python/src/ergon/connector/nylas/README.md
@@ -65,7 +65,7 @@ Após obter o `grant_id`, passe-o para `NylasClient` nas operações do connecto
 | `NylasClient` | Credenciais (`api_key`, `grant_id`, `api_uri`) |
 | `NylasConsumerConfig` | Filtros de fetch, batch, download de anexos, ack |
 | `NylasProducerConfig` | Modo de envio (`send` ou `draft`), remetente padrão |
-| `AckActionConfig` | Ações pós-processamento (marcar lido, mover pasta, star) |
+| `AckActionConfig` | Ações pós-processamento (marcar lido, mover pasta, star, delete) |
 
 ## Async Nylas Connector (recomendado)
 
@@ -142,7 +142,9 @@ Use `service.list_folders()` para descobrir IDs de pasta para o filtro `in_`.
 
 1. **Fetch**: `fetch_transactions_async` retorna `Transaction` com payload da mensagem e metadata (`thread_id`, `attachments`, `unread`).
 2. **Process**: A task executa a lógica de negócio.
-3. **Ack**: `ack_transaction` aplica `AckActionConfig` (marcar lido, mover pasta, star).
+3. **Ack**: `ack_transaction` aplica `AckActionConfig` (marcar lido, mover pasta, star, ou delete permanente).
+
+Com `AckActionConfig(delete=True)`, o connector chama `messages.destroy` e **ignora** as demais ações de update (mark_as_read / move / star / archive). Para remoção suave (sem hard-delete), use `move_to_folder_id` apontando para a pasta Trash/Lixeira do provedor.
 
 `nack_transaction` é no-op para Nylas — mensagens permanecem disponíveis para refetch.
 

--- a/sdks/python/src/ergon/connector/nylas/README.md
+++ b/sdks/python/src/ergon/connector/nylas/README.md
@@ -142,9 +142,9 @@ Use `service.list_folders()` para descobrir IDs de pasta para o filtro `in_`.
 
 1. **Fetch**: `fetch_transactions_async` retorna `Transaction` com payload da mensagem e metadata (`thread_id`, `attachments`, `unread`).
 2. **Process**: A task executa a lógica de negócio.
-3. **Ack**: `ack_transaction` aplica `AckActionConfig` (marcar lido, mover pasta, star, ou delete permanente).
+3. **Ack**: `ack_transaction` aplica `AckActionConfig` (marcar lido, mover pasta, star, ou hard-delete).
 
-Com `AckActionConfig(delete=True)`, o connector chama `messages.destroy` e **ignora** as demais ações de update (mark_as_read / move / star / archive). Para remoção suave (sem hard-delete), use `move_to_folder_id` apontando para a pasta Trash/Lixeira do provedor.
+Com `AckActionConfig(delete=True)`, o connector chama o endpoint de hard-delete de mensagens com `hard_delete=true` e **ignora** as demais ações de update (mark_as_read / move / star / archive). É necessário habilitar **Enable hard delete** no Nylas Dashboard. Essa opção é suportada apenas quando `fetch_unit="message"`; com `fetch_unit="thread"`, o ack falha explicitamente porque o ID da transação é um thread ID. Para remoção suave (sem hard-delete), use `move_to_folder_id` apontando para a pasta Trash/Lixeira do provedor.
 
 `nack_transaction` é no-op para Nylas — mensagens permanecem disponíveis para refetch.
 

--- a/sdks/python/src/ergon/connector/nylas/async_connector.py
+++ b/sdks/python/src/ergon/connector/nylas/async_connector.py
@@ -113,6 +113,8 @@ class AsyncNylasConnector(AsyncConnector):
             return
 
         if config.delete:
+            if transaction.metadata.get("fetch_unit") == "thread":
+                raise ValueError("AckActionConfig(delete=True) is only supported for message transactions")
             await self.service.delete_message(transaction.id)
             return
 

--- a/sdks/python/src/ergon/connector/nylas/async_connector.py
+++ b/sdks/python/src/ergon/connector/nylas/async_connector.py
@@ -112,6 +112,10 @@ class AsyncNylasConnector(AsyncConnector):
         if config is None:
             return
 
+        if config.delete:
+            await self.service.delete_message(transaction.id)
+            return
+
         body = build_ack_request_body(config)
         if not body:
             return

--- a/sdks/python/src/ergon/connector/nylas/async_service.py
+++ b/sdks/python/src/ergon/connector/nylas/async_service.py
@@ -116,6 +116,9 @@ class AsyncNylasService:
     async def update_message(self, message_id: str, request_body: Dict[str, Any]) -> Dict[str, Any]:
         return await asyncio.to_thread(self._sync.update_message, message_id, request_body)
 
+    async def delete_message(self, message_id: str) -> None:
+        await asyncio.to_thread(self._sync.delete_message, message_id)
+
     async def list_folders(self) -> List[Dict[str, Any]]:
         return await asyncio.to_thread(self._sync.list_folders)
 

--- a/sdks/python/src/ergon/connector/nylas/connector.py
+++ b/sdks/python/src/ergon/connector/nylas/connector.py
@@ -102,6 +102,10 @@ class NylasConnector(Connector):
         if config is None:
             return
 
+        if config.delete:
+            self.service.delete_message(transaction.id)
+            return
+
         body = build_ack_request_body(config)
         if not body:
             return

--- a/sdks/python/src/ergon/connector/nylas/connector.py
+++ b/sdks/python/src/ergon/connector/nylas/connector.py
@@ -103,6 +103,8 @@ class NylasConnector(Connector):
             return
 
         if config.delete:
+            if transaction.metadata.get("fetch_unit") == "thread":
+                raise ValueError("AckActionConfig(delete=True) is only supported for message transactions")
             self.service.delete_message(transaction.id)
             return
 

--- a/sdks/python/src/ergon/connector/nylas/models.py
+++ b/sdks/python/src/ergon/connector/nylas/models.py
@@ -85,7 +85,8 @@ class AckActionConfig(BaseModel):
     delete: bool = Field(
         default=False,
         description=(
-            "Permanently delete message on ack via messages.destroy. "
+            "Permanently delete message on ack via the Nylas hard_delete API. "
+            "Requires hard delete to be enabled in the Nylas Dashboard. "
             "When True, other ack actions (mark_as_read, move, star, archive) are skipped."
         ),
     )

--- a/sdks/python/src/ergon/connector/nylas/models.py
+++ b/sdks/python/src/ergon/connector/nylas/models.py
@@ -82,6 +82,13 @@ class AckActionConfig(BaseModel):
     move_to_folder_id: Optional[str] = Field(default=None, description="Folder ID to move message to")
     add_star: bool = Field(default=False, description="Star message on ack")
     archive: bool = Field(default=False, description="Archive message on ack (provider-specific)")
+    delete: bool = Field(
+        default=False,
+        description=(
+            "Permanently delete message on ack via messages.destroy. "
+            "When True, other ack actions (mark_as_read, move, star, archive) are skipped."
+        ),
+    )
 
 
 class NylasAuthClient(BaseModel):

--- a/sdks/python/src/ergon/connector/nylas/service.py
+++ b/sdks/python/src/ergon/connector/nylas/service.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Any, Dict, List, Optional
+from urllib.parse import quote
 
 from ..transaction import Transaction
 from .models import (
@@ -260,7 +261,12 @@ class NylasService:
         return data if isinstance(data, dict) else serialize_nylas_object(data)
 
     def delete_message(self, message_id: str) -> None:
-        self._nylas.messages.destroy(self.grant_id, message_id)
+        # nylas>=6 does not expose DELETE query parameters on messages.destroy().
+        self._nylas.http_client._execute(
+            method="DELETE",
+            path=f"/v3/grants/{self.grant_id}/messages/{quote(message_id, safe='')}",
+            query_params={"hard_delete": "true"},
+        )
 
     def list_folders(self) -> List[Dict[str, Any]]:
         response = self._nylas.folders.list(self.grant_id)

--- a/sdks/python/src/ergon/connector/nylas/service.py
+++ b/sdks/python/src/ergon/connector/nylas/service.py
@@ -259,6 +259,9 @@ class NylasService:
         data = extract_response_data(response)
         return data if isinstance(data, dict) else serialize_nylas_object(data)
 
+    def delete_message(self, message_id: str) -> None:
+        self._nylas.messages.destroy(self.grant_id, message_id)
+
     def list_folders(self) -> List[Dict[str, Any]]:
         response = self._nylas.folders.list(self.grant_id)
         data = extract_response_data(response) or []

--- a/sdks/python/src/ergon/connector/nylas/utils.py
+++ b/sdks/python/src/ergon/connector/nylas/utils.py
@@ -62,13 +62,9 @@ def merge_query_filter(
     query_field_names = set(MessageQueryFilter.model_fields.keys())
     merged: Dict[str, Any] = {}
     if base is not None:
-        merged.update(
-            {k: v for k, v in base.model_dump(exclude_none=True).items() if k in query_field_names}
-        )
+        merged.update({k: v for k, v in base.model_dump(exclude_none=True).items() if k in query_field_names})
     if overrides is not None:
-        merged.update(
-            {k: v for k, v in overrides.model_dump(exclude_none=True).items() if k in query_field_names}
-        )
+        merged.update({k: v for k, v in overrides.model_dump(exclude_none=True).items() if k in query_field_names})
     for key, value in kwargs.items():
         if value is not None and key in query_field_names:
             merged[key] = value

--- a/sdks/python/src/ergon/connector/nylas/utils.py
+++ b/sdks/python/src/ergon/connector/nylas/utils.py
@@ -63,10 +63,12 @@ def merge_query_filter(
     merged: Dict[str, Any] = {}
     if base is not None:
         merged.update(
-            {k: v for k, v in base.model_dump(exclude_none=True, by_alias=True).items() if k in query_field_names}
+            {k: v for k, v in base.model_dump(exclude_none=True).items() if k in query_field_names}
         )
     if overrides is not None:
-        merged.update(overrides.model_dump(exclude_none=True, by_alias=True))
+        merged.update(
+            {k: v for k, v in overrides.model_dump(exclude_none=True).items() if k in query_field_names}
+        )
     for key, value in kwargs.items():
         if value is not None and key in query_field_names:
             merged[key] = value

--- a/sdks/python/tests/connector/nylas/test_async_connector.py
+++ b/sdks/python/tests/connector/nylas/test_async_connector.py
@@ -113,3 +113,18 @@ class TestAckTransaction:
         connector = _make_connector(consumer_config=config)
         tx = Transaction(id="msg-1", payload={})
         await connector.nack_transaction(tx)
+
+    async def test_ack_delete_skips_update(self):
+        ack = AckActionConfig(delete=True, mark_as_read=True, add_star=True)
+        config = NylasConsumerConfig(ack_config=ack)
+        connector = _make_connector(consumer_config=config)
+        tx = Transaction(id="msg-1", payload={"id": "msg-1"})
+
+        with (
+            patch.object(connector.service, "delete_message", new_callable=AsyncMock) as mock_delete,
+            patch.object(connector.service, "update_message", new_callable=AsyncMock) as mock_update,
+        ):
+            await connector.ack_transaction(tx)
+
+        mock_delete.assert_awaited_once_with("msg-1")
+        mock_update.assert_not_awaited()

--- a/sdks/python/tests/connector/nylas/test_async_connector.py
+++ b/sdks/python/tests/connector/nylas/test_async_connector.py
@@ -128,3 +128,14 @@ class TestAckTransaction:
 
         mock_delete.assert_awaited_once_with("msg-1")
         mock_update.assert_not_awaited()
+
+    async def test_ack_delete_rejects_thread_transactions(self):
+        config = NylasConsumerConfig(ack_config=AckActionConfig(delete=True))
+        connector = _make_connector(consumer_config=config)
+        tx = Transaction(id="thread-1", payload={}, metadata={"fetch_unit": "thread"})
+
+        with patch.object(connector.service, "delete_message", new_callable=AsyncMock) as mock_delete:
+            with pytest.raises(ValueError, match="only supported for message transactions"):
+                await connector.ack_transaction(tx)
+
+        mock_delete.assert_not_awaited()

--- a/sdks/python/tests/connector/nylas/test_async_service.py
+++ b/sdks/python/tests/connector/nylas/test_async_service.py
@@ -1,0 +1,26 @@
+"""Tests for AsyncNylasService — async delegation to the sync service."""
+
+from unittest.mock import patch
+
+import pytest
+
+from ergon.connector.nylas.async_service import AsyncNylasService
+from ergon.connector.nylas.models import NylasClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+def _make_service() -> AsyncNylasService:
+    client = NylasClient(api_key="key", grant_id="grant-1")
+    with patch("ergon.connector.nylas.service._get_nylas_client"):
+        return AsyncNylasService(client)
+
+
+class TestDeleteMessage:
+    async def test_delegates_to_sync_service(self):
+        service = _make_service()
+
+        with patch.object(service._sync, "delete_message") as mock_delete:
+            await service.delete_message("msg-1")
+
+        mock_delete.assert_called_once_with("msg-1")

--- a/sdks/python/tests/connector/nylas/test_connector.py
+++ b/sdks/python/tests/connector/nylas/test_connector.py
@@ -128,6 +128,21 @@ class TestAckTransaction:
 
         mock_update.assert_not_called()
 
+    def test_ack_delete_skips_update(self):
+        ack = AckActionConfig(delete=True, mark_as_read=True, move_to_folder_id="processed-folder")
+        config = NylasConsumerConfig(ack_config=ack)
+        connector = _make_connector(consumer_config=config)
+        tx = Transaction(id="msg-1", payload={"id": "msg-1"})
+
+        with (
+            patch.object(connector.service, "delete_message") as mock_delete,
+            patch.object(connector.service, "update_message") as mock_update,
+        ):
+            connector.ack_transaction(tx)
+
+        mock_delete.assert_called_once_with("msg-1")
+        mock_update.assert_not_called()
+
 
 class TestFetchById:
     def test_fetch_transaction_by_id(self):

--- a/sdks/python/tests/connector/nylas/test_connector.py
+++ b/sdks/python/tests/connector/nylas/test_connector.py
@@ -143,6 +143,17 @@ class TestAckTransaction:
         mock_delete.assert_called_once_with("msg-1")
         mock_update.assert_not_called()
 
+    def test_ack_delete_rejects_thread_transactions(self):
+        config = NylasConsumerConfig(ack_config=AckActionConfig(delete=True))
+        connector = _make_connector(consumer_config=config)
+        tx = Transaction(id="thread-1", payload={}, metadata={"fetch_unit": "thread"})
+
+        with patch.object(connector.service, "delete_message") as mock_delete:
+            with pytest.raises(ValueError, match="only supported for message transactions"):
+                connector.ack_transaction(tx)
+
+        mock_delete.assert_not_called()
+
 
 class TestFetchById:
     def test_fetch_transaction_by_id(self):

--- a/sdks/python/tests/connector/nylas/test_service.py
+++ b/sdks/python/tests/connector/nylas/test_service.py
@@ -88,6 +88,20 @@ class TestSendMessage:
         service._nylas.messages.send.assert_called_once()
 
 
+class TestDeleteMessage:
+    def test_hard_deletes_message_via_sdk_http_client(self):
+        service = _make_service()
+
+        service.delete_message("message/1")
+
+        service._nylas.http_client._execute.assert_called_once_with(
+            method="DELETE",
+            path="/v3/grants/grant-1/messages/message%2F1",
+            query_params={"hard_delete": "true"},
+        )
+        service._nylas.messages.destroy.assert_not_called()
+
+
 class TestGetMessagesCount:
     def test_counts_across_pages(self):
         service = _make_service()

--- a/sdks/python/tests/connector/nylas/test_utils.py
+++ b/sdks/python/tests/connector/nylas/test_utils.py
@@ -28,6 +28,33 @@ class TestMergeQueryFilter:
         query = merge_query_filter(config, MessageQueryFilter(subject="Override"))
         assert query.subject == "Override"
 
+    def test_preserves_aliased_fields(self):
+        config = NylasConsumerConfig(
+            in_="Label_7008109963921275738",
+            from_=["sender@example.com"],
+            unread=True,
+            batch_size=10,
+            download_attachments=True,
+            ack_config=AckActionConfig(mark_as_read=True),
+        )
+        merged = merge_query_filter(config)
+        assert merged.in_ == "Label_7008109963921275738"
+        assert merged.from_ == ["sender@example.com"]
+        assert merged.to_query_params(limit=10) == {
+            "in": "Label_7008109963921275738",
+            "from": ["sender@example.com"],
+            "unread": True,
+            "limit": 10,
+        }
+
+    def test_override_preserves_aliased_fields(self):
+        config = NylasConsumerConfig(in_="INBOX", unread=True)
+        overrides = MessageQueryFilter(in_="Label_override", from_=["a@b.com"])
+        merged = merge_query_filter(config, overrides)
+        assert merged.in_ == "Label_override"
+        assert merged.from_ == ["a@b.com"]
+        assert merged.unread is True
+
 
 class TestClientSideFilter:
     def test_subject_contains_case_insensitive(self):


### PR DESCRIPTION
## Summary
- Fix `merge_query_filter` dropping aliased fields (`in_`, `from_`) so folder/sender filters are applied on fetch (#70).
- Add `AckActionConfig.delete` and wire sync/async ack to `messages.destroy`, skipping redundant `update_message` (#69).
- Cover both behaviors with unit tests and document the delete ack path.

## Test plan
- [x] `pytest tests/connector/nylas/test_utils.py tests/connector/nylas/test_connector.py tests/connector/nylas/test_async_connector.py` (24 passed)
- [ ] Confirm `NylasConsumerConfig(in_="Label_…")` reaches `to_query_params()` with `"in"`
- [ ] Confirm `AckActionConfig(delete=True)` destroys the message and does not call update

Closes #69
Closes #70