### PR TITLE
fix(ergon-platform): avoid accidental nack visibility cooldown

### DIFF
--- a/sdks/python/examples/ergon_platform/README.md
+++ b/sdks/python/examples/ergon_platform/README.md
@@ -29,3 +29,5 @@ cp examples/ergon_platform/.env.example examples/ergon_platform/.env
 
 - `uso_direto_async.py` — uso direto do connector (fetch → processa → ack), sem runner.
 - `task_consumer.py` — integração completa com `TaskConfig` + `AsyncConsumerTask` + runner em loop contínuo.
+
+No nack com `requeue=True`, o default de `delay_seconds` é `0` (sem override no item). Valores `> 0` são arredondados para cima em minutos (`10` → 1 min). Detalhes: [README do módulo](../../src/ergon/connector/ergon_platform/README.md#nack).

--- a/sdks/python/src/ergon/connector/ergon_platform/README.md
+++ b/sdks/python/src/ergon/connector/ergon_platform/README.md
@@ -242,16 +242,27 @@ result = connector.get_pipeline_result("wf-1", "item-1", "field-1")
 
 ## Ack
 
-Ao contrário dos brokers, o ack tem **semântica de domínio**: move o item para `ack_phase_id`. Sem `ack_phase_id` configurado, o ack é no-op. Em uma `AsyncConsumerTask`, chame `ack_transaction` em `handle_process_success`.
+Ao contrário dos brokers, o ack tem **semântica de domínio**: move o item para `ack_phase_id` via `items.route`. Sem `ack_phase_id` configurado, o ack é no-op. Em uma `AsyncConsumerTask`, chame `ack_transaction` em `handle_process_success`.
+
+O caminho de ack **não** escreve `visibility_timeout_on_release_minutes` / `visible_after` no connector. Se um `route`/`comment` retornar `409 Item is in visibility cooldown`, a causa costuma ser cooldown de **transição** ou de um **release anterior** (nack / auto-release por `timeout_minutes` da fase) — não o próprio `ack_transaction`.
 
 ## Nack
 
 `nack_transaction` também usa semântica de domínio:
 
-- `requeue=True`: faz `release_item`, mantendo o mesmo card. Quando `delay_seconds > 0`, o connector converte o valor para minutos com arredondamento para cima, atualiza o item com `visibility_timeout_on_release_minutes` e só então chama `release`. A plataforma usa esse valor para preencher `visible_after`.
+- `requeue=True`: faz `release_item`, mantendo o mesmo card. O default de `delay_seconds` é **`0`** (sem override no item).
 - `requeue=False`: move o item para `nack_phase_id` (fase de erro), que deve estar configurada no `ErgonPlatformConsumerConfig`.
 
-O delay efetivo da plataforma é em minutos. Por isso, `delay_seconds=1` até `60` vira `visibility_timeout_on_release_minutes=1`; `delay_seconds=61` até `120` vira `2`, e assim por diante. Se o update do timeout falhar, o release não deve prosseguir, para evitar reentrada imediata na fila.
+### Semântica de `delay_seconds` no release
+
+| Valor | Efeito no connector | Efeito na Platform |
+|-------|---------------------|--------------------|
+| `None` / omitido / `0` | Não faz PATCH de `visibility_timeout_on_release_minutes` | Aplica o cooldown da **fase** (se houver). **Não** força “sem cooldown”. |
+| `> 0` | `PATCH` com `ceil(delay_seconds / 60)` minutos, depois `release` | Usa o override do item para preencher `visible_after` |
+
+O delay efetivo da plataforma é em **minutos**. Por isso, `delay_seconds=1` até `60` vira `visibility_timeout_on_release_minutes=1` (incluindo o antigo default `10` → **1 minuto**). `61`–`120` vira `2`, e assim por diante. Se o update do timeout falhar, o release não deve prosseguir, para evitar reentrada imediata na fila.
+
+Para RPAs longos: aumente `timeout_minutes` da fase (evita auto-release mid-run) e não confie só em `delay_seconds=0` para desligar cooldown — isso ainda depende da config da fase / suporte da Platform a override `0`.
 
 ## Recomendações de uso
 

--- a/sdks/python/src/ergon/connector/ergon_platform/_operations.py
+++ b/sdks/python/src/ergon/connector/ergon_platform/_operations.py
@@ -140,6 +140,15 @@ class _ErgonPlatformOperations:
         delay_seconds: Optional[int] = None,
         **fields: Any,
     ) -> Any:
+        """Release an item, optionally setting an item-level visibility cooldown.
+
+        ``delay_seconds`` semantics:
+        - ``None`` or ``0``: do **not** PATCH ``visibility_timeout_on_release_minutes``.
+          Platform still applies the **phase** ``visibility_timeout_on_release_minutes``
+          on release (item override ``0`` is not expressible as "force no cooldown").
+        - ``> 0``: PATCH ``visibility_timeout_on_release_minutes = ceil(delay_seconds / 60)``
+          then release. Sub-minute values (e.g. 10s) become **1 minute**.
+        """
         if delay_seconds is not None:
             if delay_seconds < 0:
                 raise ValueError("delay_seconds must be a non-negative integer")

--- a/sdks/python/src/ergon/connector/ergon_platform/async_connector.py
+++ b/sdks/python/src/ergon/connector/ergon_platform/async_connector.py
@@ -140,7 +140,14 @@ class AsyncErgonPlatformConnector(AsyncConnector):
             )
         )
 
-    async def nack_transaction(self, transaction: Transaction, requeue: bool = True, delay_seconds: int = 10) -> None:
+    async def nack_transaction(self, transaction: Transaction, requeue: bool = True, delay_seconds: int = 0) -> None:
+        """Nack a transaction.
+
+        When ``requeue=True``, releases the item. ``delay_seconds`` defaults to ``0``
+        (no item-level override; Platform phase cooldown still applies if configured).
+        Values ``> 0`` are rounded up to whole minutes via ``ceil(delay_seconds / 60)``
+        before release — e.g. ``10`` becomes **1 minute**, not 10 seconds.
+        """
         if requeue:
             await asyncio.to_thread(lambda: self._operations.release_item(transaction.id, delay_seconds=delay_seconds))
             return

--- a/sdks/python/src/ergon/connector/ergon_platform/connector.py
+++ b/sdks/python/src/ergon/connector/ergon_platform/connector.py
@@ -126,7 +126,14 @@ class ErgonPlatformConnector(Connector):
             **fields,
         )
 
-    def nack_transaction(self, transaction: Transaction, requeue: bool = True, delay_seconds: int = 10) -> None:
+    def nack_transaction(self, transaction: Transaction, requeue: bool = True, delay_seconds: int = 0) -> None:
+        """Nack a transaction.
+
+        When ``requeue=True``, releases the item. ``delay_seconds`` defaults to ``0``
+        (no item-level override; Platform phase cooldown still applies if configured).
+        Values ``> 0`` are rounded up to whole minutes via ``ceil(delay_seconds / 60)``
+        before release — e.g. ``10`` becomes **1 minute**, not 10 seconds.
+        """
         if requeue:
             self._operations.release_item(transaction.id, delay_seconds=delay_seconds)
             return

--- a/sdks/python/tests/connector/ergon_platform/test_async_connector.py
+++ b/sdks/python/tests/connector/ergon_platform/test_async_connector.py
@@ -259,6 +259,17 @@ class TestAckTransaction:
 
         assert sdk_client.workflows.items.route_calls == []
 
+    async def test_ack_does_not_set_release_visibility_cooldown(self):
+        config = ErgonPlatformConsumerConfig(workflow_id="wf", phase_id="ph", ack_phase_id="done")
+        sdk_client = _Client()
+        connector = _make_connector(consumer_config=config, sdk_client=sdk_client)
+
+        await connector.ack_transaction(Transaction(id="item-1", payload={}))
+
+        assert sdk_client.workflows.items.update_calls == []
+        assert sdk_client.workflows.items.release_calls == []
+        assert sdk_client.workflows.items.route_calls == [("item-1", "done")]
+
 
 class TestReleaseItem:
     async def test_release_forwards_delay_seconds_to_domain_operation(self):
@@ -269,6 +280,15 @@ class TestReleaseItem:
 
         assert result == {"id": "item-1", "released": True}
         assert sdk_client.workflows.items.update_calls == [("item-1", {"visibility_timeout_on_release_minutes": 2})]
+        assert sdk_client.workflows.items.release_calls == [("item-1", {})]
+
+    async def test_release_with_delay_seconds_zero_skips_visibility_override(self):
+        sdk_client = _Client()
+        connector = _make_connector(sdk_client=sdk_client)
+
+        await connector.release_item("item-1", delay_seconds=0)
+
+        assert sdk_client.workflows.items.update_calls == []
         assert sdk_client.workflows.items.release_calls == [("item-1", {})]
 
 
@@ -282,6 +302,15 @@ class TestNackTransaction:
         assert sdk_client.workflows.items.release_calls == [("item-1", {})]
         assert sdk_client.workflows.items.update_calls == []
 
+    async def test_nack_default_delay_does_not_set_visibility_override(self):
+        sdk_client = _Client()
+        connector = _make_connector(sdk_client=sdk_client)
+
+        await connector.nack_transaction(Transaction(id="item-1", payload={}), requeue=True)
+
+        assert sdk_client.workflows.items.release_calls == [("item-1", {})]
+        assert sdk_client.workflows.items.update_calls == []
+
     async def test_nack_requeue_updates_release_delay_before_release(self):
         sdk_client = _Client()
         connector = _make_connector(sdk_client=sdk_client)
@@ -289,6 +318,15 @@ class TestNackTransaction:
         await connector.nack_transaction(Transaction(id="item-1", payload={}), requeue=True, delay_seconds=75)
 
         assert sdk_client.workflows.items.update_calls == [("item-1", {"visibility_timeout_on_release_minutes": 2})]
+        assert sdk_client.workflows.items.release_calls == [("item-1", {})]
+
+    async def test_nack_sub_minute_delay_rounds_up_to_one_minute(self):
+        sdk_client = _Client()
+        connector = _make_connector(sdk_client=sdk_client)
+
+        await connector.nack_transaction(Transaction(id="item-1", payload={}), requeue=True, delay_seconds=10)
+
+        assert sdk_client.workflows.items.update_calls == [("item-1", {"visibility_timeout_on_release_minutes": 1})]
         assert sdk_client.workflows.items.release_calls == [("item-1", {})]
 
     async def test_nack_without_requeue_moves_to_nack_phase(self):

--- a/sdks/python/tests/connector/ergon_platform/test_connector.py
+++ b/sdks/python/tests/connector/ergon_platform/test_connector.py
@@ -277,6 +277,17 @@ class TestAckTransaction:
 
         assert sdk_client.workflows.items.route_calls == []
 
+    def test_ack_does_not_set_release_visibility_cooldown(self):
+        config = ErgonPlatformConsumerConfig(workflow_id="wf", phase_id="ph", ack_phase_id="done")
+        sdk_client = _Client()
+        connector = _make_connector(consumer_config=config, sdk_client=sdk_client)
+
+        connector.ack_transaction(Transaction(id="item-1", payload={}))
+
+        assert sdk_client.workflows.items.update_calls == []
+        assert sdk_client.workflows.items.release_calls == []
+        assert sdk_client.workflows.items.route_calls == [("item-1", "done")]
+
 
 class TestReleaseItem:
     def test_release_forwards_delay_seconds_to_domain_operation(self):
@@ -287,6 +298,15 @@ class TestReleaseItem:
 
         assert result == {"id": "item-1", "released": True}
         assert sdk_client.workflows.items.update_calls == [("item-1", {"visibility_timeout_on_release_minutes": 2})]
+        assert sdk_client.workflows.items.release_calls == [("item-1", {})]
+
+    def test_release_with_delay_seconds_zero_skips_visibility_override(self):
+        sdk_client = _Client()
+        connector = _make_connector(sdk_client=sdk_client)
+
+        connector.release_item("item-1", delay_seconds=0)
+
+        assert sdk_client.workflows.items.update_calls == []
         assert sdk_client.workflows.items.release_calls == [("item-1", {})]
 
 
@@ -300,6 +320,15 @@ class TestNackTransaction:
         assert sdk_client.workflows.items.release_calls == [("item-1", {})]
         assert sdk_client.workflows.items.update_calls == []
 
+    def test_nack_default_delay_does_not_set_visibility_override(self):
+        sdk_client = _Client()
+        connector = _make_connector(sdk_client=sdk_client)
+
+        connector.nack_transaction(Transaction(id="item-1", payload={}), requeue=True)
+
+        assert sdk_client.workflows.items.release_calls == [("item-1", {})]
+        assert sdk_client.workflows.items.update_calls == []
+
     def test_nack_requeue_updates_release_delay_before_release(self):
         sdk_client = _Client()
         connector = _make_connector(sdk_client=sdk_client)
@@ -307,6 +336,15 @@ class TestNackTransaction:
         connector.nack_transaction(Transaction(id="item-1", payload={}), requeue=True, delay_seconds=75)
 
         assert sdk_client.workflows.items.update_calls == [("item-1", {"visibility_timeout_on_release_minutes": 2})]
+        assert sdk_client.workflows.items.release_calls == [("item-1", {})]
+
+    def test_nack_sub_minute_delay_rounds_up_to_one_minute(self):
+        sdk_client = _Client()
+        connector = _make_connector(sdk_client=sdk_client)
+
+        connector.nack_transaction(Transaction(id="item-1", payload={}), requeue=True, delay_seconds=10)
+
+        assert sdk_client.workflows.items.update_calls == [("item-1", {"visibility_timeout_on_release_minutes": 1})]
         assert sdk_client.workflows.items.release_calls == [("item-1", {})]
 
     def test_nack_without_requeue_moves_to_nack_phase(self):

--- a/sdks/python/tests/connector/ergon_platform/test_service.py
+++ b/sdks/python/tests/connector/ergon_platform/test_service.py
@@ -213,6 +213,25 @@ class TestReleaseWithDelaySeconds:
             ("release", "item-1", {}),
         ]
 
+    def test_release_with_delay_seconds_zero_does_not_update_visibility_timeout(self):
+        operations = _make_operations()
+
+        operations.release_item("item-1", delay_seconds=0)
+
+        assert operations.client.workflows.items.calls == [
+            ("release", "item-1", {}),
+        ]
+
+    def test_release_sub_minute_delay_rounds_up_to_one_minute(self):
+        operations = _make_operations()
+
+        operations.release_item("item-1", delay_seconds=10)
+
+        assert operations.client.workflows.items.calls == [
+            ("update", "item-1", {"visibility_timeout_on_release_minutes": 1}),
+            ("release", "item-1", {}),
+        ]
+
     def test_release_rejects_negative_delay_seconds(self):
         operations = _make_operations()
 


### PR DESCRIPTION
## Summary
- Change `nack_transaction(..., delay_seconds=0)` default (was `10`, which became **1 minute** via `ceil(10/60)`).
- Document ack/nack/release visibility cooldown semantics: ack only `route`s; `delay_seconds=0`/`None` skips item override and still inherits phase cooldown.
- Add unit tests for ack not touching cooldown, default nack, `delay_seconds=0`, and sub-minute rounding.

## Notes
Forcing “no cooldown” via item override `0` still needs Platform support (override `0` currently falls back to phase). Consumer guidance for long RPAs: raise phase `timeout_minutes`; do not rely on `delay_seconds=0` alone.

## Test plan
- [x] `pytest tests/connector/ergon_platform/` (86 passed)
- [ ] Confirm consumers that needed a requeue delay pass an explicit `delay_seconds` (e.g. 30/60)

Related to #63