### PR TITLE
chore(release): cut 0.2.1

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ergon-framework-python"
-version = "0.2.0"
+version = "0.2.1"
 description = "Ergon internal task-oriented project bootstrapper"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/src/ergon/__init__.py
+++ b/sdks/python/src/ergon/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "manager",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/sdks/python/tests/test_smoke.py
+++ b/sdks/python/tests/test_smoke.py
@@ -4,4 +4,4 @@ import ergon
 
 
 def test_ergon_package_is_importable() -> None:
-    assert ergon.__version__ == "0.2.0"
+    assert ergon.__version__ == "0.2.1"


### PR DESCRIPTION
## Summary
- Bump version from 0.2.0 to 0.2.1 in `pyproject.toml`, `ergon.__version__`, and the smoke test.
- Cuts a release that includes #71 (fix(nylas): preserve aliased query filters and add ack delete), which landed on main after the v0.2.0 tag.

## After merging
- Tag the merge commit as `v0.2.1` so the tag, `pyproject.toml`, and published artifact stay in sync.

Made with [Cursor](https://cursor.com)