### PR TITLE
chore(release): cut 0.3.0

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ergon-framework-python"
-version = "0.2.1"
+version = "0.3.0"
 description = "Ergon internal task-oriented project bootstrapper"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/src/ergon/__init__.py
+++ b/sdks/python/src/ergon/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "manager",
 ]
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/sdks/python/tests/test_smoke.py
+++ b/sdks/python/tests/test_smoke.py
@@ -4,4 +4,4 @@ import ergon
 
 
 def test_ergon_package_is_importable() -> None:
-    assert ergon.__version__ == "0.2.1"
+    assert ergon.__version__ == "0.3.0"


### PR DESCRIPTION
## Summary
- Bump `ergon-framework-python` from 0.2.1 to 0.3.0.
- Release the Channels connector, inbox-scoped claim/lease lifecycle, and attachment handling merged in #74.
- Keep package metadata, runtime `__version__`, and the smoke test synchronized.

## Test plan
- [x] `uv run pytest -q` (456 passed)
- [x] `uv run pyright`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv build`

## After merging
- Tag the merge commit as `v0.3.0` to trigger the PyPI release workflow.

Refs #74

Made with [Cursor](https://cursor.com)