### PR TITLE
fix(release): correct version to 0.2.2

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ergon-framework-python"
-version = "0.3.0"
+version = "0.2.2"
 description = "Ergon internal task-oriented project bootstrapper"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/src/ergon/__init__.py
+++ b/sdks/python/src/ergon/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "manager",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.2.2"

--- a/sdks/python/tests/test_smoke.py
+++ b/sdks/python/tests/test_smoke.py
@@ -4,4 +4,4 @@ import ergon
 
 
 def test_ergon_package_is_importable() -> None:
-    assert ergon.__version__ == "0.3.0"
+    assert ergon.__version__ == "0.2.2"


### PR DESCRIPTION
## Summary
- Correct the unpublished release version from 0.3.0 to 0.2.2.
- Keep package metadata, runtime `__version__`, and the smoke test synchronized.
- Preserve the existing 0.2 release line for the Channels changes merged in #74.

## Test plan
- [x] `uv run pytest -q` (456 passed)
- [x] `uv run pyright`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv build`

## After merging
- Tag the merge commit as `v0.2.2` to trigger the PyPI release workflow.

Refs #74

Made with [Cursor](https://cursor.com)