### PR TITLE
fix(rabbitmq): close failed initial robust connections

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ergon-framework-python"
-version = "0.2.1"
+version = "0.2.2"
 description = "Ergon internal task-oriented project bootstrapper"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ergon-framework-python"
-version = "0.2.2"
+version = "0.2.3"
 description = "Ergon internal task-oriented project bootstrapper"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/src/ergon/__init__.py
+++ b/sdks/python/src/ergon/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "manager",
 ]
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/sdks/python/src/ergon/__init__.py
+++ b/sdks/python/src/ergon/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "manager",
 ]
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/sdks/python/src/ergon/connector/rabbitmq/async_service.py
+++ b/sdks/python/src/ergon/connector/rabbitmq/async_service.py
@@ -55,13 +55,14 @@ _DEAD_CHANNEL_EXCEPTIONS: tuple[type[BaseException], ...] = (
     aio_pika.exceptions.ChannelClosed,
 )
 
-# Same as above plus ``TimeoutError`` (raised by the async timeout context when an
-# ack/nack stalls on a half-open socket). A stalled ack is functionally a dead
-# channel: we tear down and let the broker redeliver instead of blocking until
-# the heartbeat eventually fires.
+# Same as above plus ``asyncio.TimeoutError`` (raised by the async timeout
+# context when an ack/nack stalls on a half-open socket). A stalled ack is
+# functionally a dead channel: we tear down and let the broker redeliver instead
+# of blocking until the heartbeat eventually fires. Use asyncio's name
+# explicitly because it is distinct from builtins.TimeoutError on Python 3.10.
 _DEAD_CHANNEL_TIMEOUT_EXCEPTIONS: tuple[type[BaseException], ...] = (
     *_DEAD_CHANNEL_EXCEPTIONS,
-    TimeoutError,
+    asyncio.TimeoutError,
 )
 
 
@@ -107,6 +108,54 @@ class AsyncRabbitMQService:
 
     # ---------- Connection / Channel ----------
 
+    async def _open_owned_robust_connection(
+        self,
+        url: str,
+        kwargs: Dict[str, Any],
+    ) -> AbstractRobustConnection:
+        """Open a robust connection without losing ownership on startup failure.
+
+        ``aio_pika.connect_robust`` constructs ``RobustConnection`` and starts
+        its background reconnection task before awaiting the initial broker
+        connection. If that await times out or is cancelled, the helper never
+        returns the connection object, so callers cannot close the reconnect
+        task and ``asyncio.run`` can hang while shutting it down.
+
+        aio-pika exposes ``connection_class`` as its connection factory. Capture
+        the object synchronously at that boundary, before its first await, and
+        close it on every unsuccessful exit from ``connect_robust``.
+        """
+        pending_connection: Optional[AbstractRobustConnection] = None
+
+        def capture_connection(*args: Any, **connection_kwargs: Any) -> AbstractRobustConnection:
+            nonlocal pending_connection
+            pending_connection = aio_pika.RobustConnection(*args, **connection_kwargs)
+            return pending_connection
+
+        connection_factory = cast(type[AbstractRobustConnection], capture_connection)
+        try:
+            async with timeout_after(self.client.connect_timeout):
+                return await aio_pika.connect_robust(  # type: ignore[call-overload]
+                    url,
+                    heartbeat=self.client.heartbeat,
+                    timeout=self.client.connect_timeout,
+                    connection_class=connection_factory,
+                    **kwargs,
+                )
+        except BaseException as exc:
+            connection_to_close = pending_connection
+            pending_connection = None
+            try:
+                await self._close_connection_safely(
+                    connection_to_close,
+                    f"initial connection attempt failed: {type(exc).__name__}",
+                )
+            finally:
+                # Do not retain the partial connection in this exception's
+                # traceback after its reconnect task has been stopped.
+                del connection_to_close
+            raise
+
     async def _get_connection(self) -> AbstractRobustConnection:
         async with self._connection_lock:
             if self._connection is not None and not self._connection.is_closed:
@@ -116,7 +165,7 @@ class AsyncRabbitMQService:
                     try:
                         async with timeout_after(self.client.connect_timeout):
                             await connected.wait()
-                    except TimeoutError:
+                    except asyncio.TimeoutError:
                         self._consumer_state = "connect_stalled"
                         await self._reset_connection("robust reconnect timed out")
                         raise
@@ -133,14 +182,8 @@ class AsyncRabbitMQService:
 
             self._consumer_state = "connecting"
             try:
-                async with timeout_after(self.client.connect_timeout):
-                    connection = await aio_pika.connect_robust(  # type: ignore[call-overload]
-                        url,
-                        heartbeat=self.client.heartbeat,
-                        timeout=self.client.connect_timeout,
-                        **kwargs,
-                    )
-            except TimeoutError:
+                connection = await self._open_owned_robust_connection(url, kwargs)
+            except asyncio.TimeoutError:
                 self._consumer_state = "connect_stalled"
                 raise
             except BaseException:
@@ -181,7 +224,7 @@ class AsyncRabbitMQService:
         try:
             async with timeout_after(close_timeout):
                 await connection.close()
-        except TimeoutError:
+        except asyncio.TimeoutError:
             logger.error(
                 "Timed out closing RabbitMQ connection after %.1fs (%s)",
                 close_timeout,
@@ -293,7 +336,7 @@ class AsyncRabbitMQService:
             try:
                 async with timeout_after(self.client.channel_timeout):
                     self._consume_channel = await connection.channel()
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 self._consumer_state = "connect_stalled"
                 await self._reset_connection("consume channel creation timed out")
                 raise
@@ -328,7 +371,7 @@ class AsyncRabbitMQService:
             try:
                 async with timeout_after(self.client.channel_timeout):
                     self._publish_channel = await connection.channel()
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 await self._reset_connection("publish channel creation timed out")
                 raise
 
@@ -455,7 +498,7 @@ class AsyncRabbitMQService:
                     break
                 if epoch == self._consumer_epoch and delivery is not None:
                     buffer.append(delivery)
-        except TimeoutError:
+        except asyncio.TimeoutError:
             poll_completed = True
         else:
             poll_completed = True

--- a/sdks/python/src/ergon/task/mixins/consumer.py
+++ b/sdks/python/src/ergon/task/mixins/consumer.py
@@ -869,7 +869,7 @@ class AsyncConsumerMixin(ABC):
                             trace_name=f"{self.__class__.__name__}.start_processing",
                             trace_attrs={"transaction_id": tr.id},
                         )
-                except TimeoutError as exc:
+                except asyncio.TimeoutError as exc:
                     timeout_error = exceptions.TransactionTimeoutException(
                         transaction_id=tr.id,
                         cause=exc,

--- a/sdks/python/tests/connector/rabbitmq/test_async_service.py
+++ b/sdks/python/tests/connector/rabbitmq/test_async_service.py
@@ -1,9 +1,11 @@
 """Tests for AsyncRabbitMQService — connection lifecycle, consume, publish, ack/nack."""
 
 import asyncio
+import gc
 import json
+import sys
 import time
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aio_pika.exceptions
@@ -64,6 +66,84 @@ def _mock_channel() -> AsyncMock:
     return channel
 
 
+class _HangingInitialRobustConnection:
+    """Model aio-pika's reconnect task before ``connect_robust`` returns."""
+
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        self.is_closed = False
+        self.close_calls = 0
+        self.reconnect_started = asyncio.Event()
+        self.reconnect_task: asyncio.Task[None] | None = None
+
+    async def _reconnect_forever(self) -> None:
+        self.reconnect_started.set()
+        await asyncio.Event().wait()
+
+    async def connect(self, timeout: float | None = None) -> None:
+        del timeout
+        self.reconnect_task = asyncio.create_task(
+            self._reconnect_forever(),
+            name="fake-aio-pika-reconnect",
+        )
+        await self.reconnect_started.wait()
+        await asyncio.Event().wait()
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        self.is_closed = True
+        if self.reconnect_task is not None:
+            self.reconnect_task.cancel()
+            await asyncio.gather(self.reconnect_task, return_exceptions=True)
+
+
+class _FailingInitialRobustConnection(_HangingInitialRobustConnection):
+    async def connect(self, timeout: float | None = None) -> None:
+        del timeout
+        self.reconnect_task = asyncio.create_task(
+            self._reconnect_forever(),
+            name="fake-aio-pika-reconnect",
+        )
+        await self.reconnect_started.wait()
+        raise aiormq.exceptions.AuthenticationError("invalid credentials")
+
+
+class _SuccessfulInitialRobustConnection(_HangingInitialRobustConnection):
+    async def connect(self, timeout: float | None = None) -> None:
+        del timeout
+
+
+def _install_initial_connect_double(
+    monkeypatch: pytest.MonkeyPatch,
+    connection_type: Any,
+) -> list[_HangingInitialRobustConnection]:
+    """Install a faithful ``connect_robust`` ownership boundary test double."""
+
+    created: list[_HangingInitialRobustConnection] = []
+
+    async def connect_robust(
+        url: str,
+        *,
+        connection_class: Any = connection_type,
+        timeout: float | None = None,
+        loop: Any = None,
+        ssl_context: Any = None,
+        **kwargs: Any,
+    ) -> Any:
+        connection = connection_class(
+            url,
+            loop=loop,
+            ssl_context=ssl_context,
+            **kwargs,
+        )
+        created.append(connection)
+        await connection.connect(timeout=timeout)
+        return connection
+
+    monkeypatch.setattr(aio_pika, "RobustConnection", connection_type)
+    monkeypatch.setattr(aio_pika, "connect_robust", connect_robust)
+    return created
+
+
 def _mock_consumer_queue(
     *,
     name: str = "test-queue",
@@ -103,6 +183,196 @@ class TestClientUrl:
 
 
 class TestConnection:
+    async def test_initial_connect_timeout_closes_reconnect_task(self, monkeypatch):
+        created = _install_initial_connect_double(monkeypatch, _HangingInitialRobustConnection)
+        service = AsyncRabbitMQService(_make_client(connect_timeout=0.02))
+
+        try:
+            with pytest.raises(asyncio.TimeoutError):
+                await service._get_connection()
+
+            assert len(created) == 1
+            connection = created[0]
+            assert connection.close_calls == 1
+            assert connection.is_closed is True
+            assert connection.reconnect_task is not None
+            assert connection.reconnect_task.done()
+            assert service._connection is None
+            assert service.health()["state"] == "connect_stalled"
+        finally:
+            for connection in created:
+                await connection.close()
+
+    async def test_initial_connect_cancellation_closes_reconnect_task(self, monkeypatch):
+        created = _install_initial_connect_double(monkeypatch, _HangingInitialRobustConnection)
+        service = AsyncRabbitMQService(_make_client(connect_timeout=30))
+        connecting = asyncio.create_task(service._get_connection())
+
+        try:
+            while not created:
+                await asyncio.sleep(0)
+            await created[0].reconnect_started.wait()
+            connecting.cancel()
+
+            with pytest.raises(asyncio.CancelledError):
+                await connecting
+
+            connection = created[0]
+            assert connection.close_calls == 1
+            assert connection.is_closed is True
+            assert connection.reconnect_task is not None
+            assert connection.reconnect_task.done()
+            assert service._connection is None
+            assert service.health()["state"] == "disconnected"
+        finally:
+            if not connecting.done():
+                connecting.cancel()
+                await asyncio.gather(connecting, return_exceptions=True)
+            for connection in created:
+                await connection.close()
+
+    async def test_initial_connect_error_closes_reconnect_task(self, monkeypatch):
+        created = _install_initial_connect_double(monkeypatch, _FailingInitialRobustConnection)
+        service = AsyncRabbitMQService(_make_client(connect_timeout=1))
+
+        try:
+            with pytest.raises(aiormq.exceptions.AuthenticationError, match="invalid credentials"):
+                await service._get_connection()
+
+            assert len(created) == 1
+            connection = created[0]
+            assert connection.close_calls == 1
+            assert connection.is_closed is True
+            assert connection.reconnect_task is not None
+            assert connection.reconnect_task.done()
+            assert service._connection is None
+            assert service.health()["state"] == "disconnected"
+        finally:
+            for connection in created:
+                await connection.close()
+
+    async def test_successful_initial_connect_transfers_ownership_to_service(self, monkeypatch):
+        created = _install_initial_connect_double(monkeypatch, _SuccessfulInitialRobustConnection)
+        service = AsyncRabbitMQService(_make_client(connect_timeout=1))
+
+        connection = cast(
+            _SuccessfulInitialRobustConnection,
+            await service._get_connection(),
+        )
+
+        assert created == [connection]
+        assert connection.close_calls == 0
+        assert connection.is_closed is False
+        assert service._connection is connection
+        assert service.health()["state"] == "connected"
+
+        await service.close()
+
+        assert connection.close_calls == 1
+        assert connection.is_closed is True
+        assert service._connection is None
+
+    async def test_retry_after_initial_timeout_uses_fresh_owned_connection(self, monkeypatch):
+        connection_types = iter(
+            [
+                _HangingInitialRobustConnection,
+                _SuccessfulInitialRobustConnection,
+            ]
+        )
+
+        def connection_factory(*args: Any, **kwargs: Any) -> _HangingInitialRobustConnection:
+            return next(connection_types)(*args, **kwargs)
+
+        created = _install_initial_connect_double(monkeypatch, connection_factory)
+        service = AsyncRabbitMQService(_make_client(connect_timeout=0.02))
+
+        with pytest.raises(asyncio.TimeoutError):
+            await service._get_connection()
+
+        connection = cast(
+            _SuccessfulInitialRobustConnection,
+            await service._get_connection(),
+        )
+
+        assert len(created) == 2
+        assert created[0].close_calls == 1
+        assert created[0].reconnect_task is not None
+        assert created[0].reconnect_task.done()
+        assert connection is created[1]
+        assert connection.close_calls == 0
+        assert service._connection is connection
+
+        await service.close()
+        assert connection.close_calls == 1
+
+    async def test_real_aio_pika_handshake_timeout_releases_reconnect_task(self, monkeypatch):
+        created = []
+        accepted_connections: set[tuple[asyncio.StreamReader, asyncio.StreamWriter]] = set()
+        real_connection_class = aio_pika.RobustConnection
+
+        def record_connection(*args: Any, **kwargs: Any) -> Any:
+            connection = real_connection_class(*args, **kwargs)
+            created.append(connection)
+            return connection
+
+        def accept_without_amqp_handshake(
+            reader: asyncio.StreamReader,
+            writer: asyncio.StreamWriter,
+        ) -> None:
+            accepted_connections.add((reader, writer))
+
+        server = await asyncio.start_server(
+            accept_without_amqp_handshake,
+            host="127.0.0.1",
+            port=0,
+        )
+        port = server.sockets[0].getsockname()[1]
+        service = AsyncRabbitMQService(
+            _make_client(
+                url=f"amqp://guest:guest@127.0.0.1:{port}/",
+                connect_timeout=0.05,
+            )
+        )
+        monkeypatch.setattr(aio_pika, "RobustConnection", record_connection)
+
+        try:
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(service._get_connection(), timeout=1)
+
+            assert len(created) == 1
+            assert (
+                getattr(
+                    created[0],
+                    "_RobustConnection__reconnection_task",
+                )
+                is None
+            )
+            assert service._connection is None
+            assert service.health()["state"] == "connect_stalled"
+            assert accepted_connections
+
+            # On production Python (3.12+) and current runtimes, aiormq also
+            # closes the partial handshake socket when its task is cancelled.
+            # Python 3.10's asyncio transport defers that final socket cleanup
+            # to collection, but the reconnect task that can wedge
+            # asyncio.run() is already deterministically gone above.
+            if sys.version_info >= (3, 11):
+                for reader, _writer in accepted_connections:
+                    await asyncio.wait_for(reader.read(), timeout=1)
+        finally:
+            await service.close()
+            for _reader, writer in accepted_connections:
+                writer.close()
+            await asyncio.gather(
+                *(writer.wait_closed() for _reader, writer in accepted_connections),
+                return_exceptions=True,
+            )
+            server.close()
+            await server.wait_closed()
+            created.clear()
+            gc.collect()
+            await asyncio.sleep(0)
+
     @patch("ergon.connector.rabbitmq.async_service.aio_pika.connect_robust", new_callable=AsyncMock)
     async def test_connect_hang_is_bounded(self, mock_connect):
         async def never_connects(*args, **kwargs):
@@ -111,7 +381,7 @@ class TestConnection:
         mock_connect.side_effect = never_connects
         service = AsyncRabbitMQService(_make_client(connect_timeout=0.02))
 
-        with pytest.raises(TimeoutError):
+        with pytest.raises(asyncio.TimeoutError):
             await service._get_connection()
 
         assert service.health()["state"] == "connect_stalled"
@@ -126,7 +396,7 @@ class TestConnection:
         service = AsyncRabbitMQService(_make_client(connect_timeout=0.02))
         service._connection = mock_conn
 
-        with pytest.raises(TimeoutError):
+        with pytest.raises(asyncio.TimeoutError):
             await service._get_connection()
 
         mock_conn.close.assert_awaited_once()

--- a/sdks/python/tests/test_smoke.py
+++ b/sdks/python/tests/test_smoke.py
@@ -4,4 +4,4 @@ import ergon
 
 
 def test_ergon_package_is_importable() -> None:
-    assert ergon.__version__ == "0.2.1"
+    assert ergon.__version__ == "0.2.2"

--- a/sdks/python/tests/test_smoke.py
+++ b/sdks/python/tests/test_smoke.py
@@ -4,4 +4,4 @@ import ergon
 
 
 def test_ergon_package_is_importable() -> None:
-    assert ergon.__version__ == "0.2.2"
+    assert ergon.__version__ == "0.2.3"


### PR DESCRIPTION
## Why this PR exists

On August 16, transient RabbitMQ connection failures left ECS workers running but no longer consuming. CloudWatch showed initial RabbitMQ connection timeouts in workers including `agents-processor-worker` and `automations-subscription-worker`. The application task failed before normal consumer startup completed, but the container process did not exit because an aio-pika background reconnect task was still alive. ECS therefore continued to count the task as running even though useful work had stopped.

The immediate operational recovery was to restart the affected ECS services. Replacement tasks connected successfully and the queues drained, including the automation backlog observed during the incident.

A broker maintenance event or temporary network interruption may have triggered the failed connection attempt, but that is not the framework defect. Any initial DNS, TCP, TLS, AMQP, credential, or broker-availability failure can enter the same lifecycle path. The defect is that the framework could lose ownership of a partially created robust connection and therefore could not guarantee cleanup or process exit.

## User-visible failure mode

1. ECS starts a worker or replaces one during a transient RabbitMQ interruption.
2. The worker calls `aio_pika.connect_robust(...)`.
3. The initial connection attempt times out before `connect_robust` returns.
4. The worker's main task fails, but an aio-pika reconnect task remains alive.
5. The process stays running without an active framework consumer.
6. The existing container health check can still pass after broker reachability returns because it checks RabbitMQ TCP/TLS connectivity, not whether the application consumer coroutine is alive and subscribed.
7. ECS does not replace the task, and CPU-based scaling has no useful signal because a zombie worker is mostly idle. Queue-based scaling may add capacity later, but it does not repair the dead process and is not a lifecycle guarantee.

This is why restarting the ECS services recovered processing, while simply waiting or increasing concurrency would not reliably fix the affected tasks.

## Exact root cause

`aio_pika.connect_robust` does more than return a connected object:

1. It constructs a `RobustConnection`.
2. `RobustConnection.connect()` starts its internal `__reconnection_task`.
3. It then awaits the first broker connection and AMQP handshake.
4. Only after that await succeeds does `connect_robust` return the connection object to the caller.

Before this PR, the framework assigned the result only after the await completed:

```python
connection = await aio_pika.connect_robust(...)
```

If the await timed out, was cancelled, or raised another exception, assignment never happened. `AsyncRabbitMQService._connection` remained `None`, even though aio-pika had already created a `RobustConnection` and started its reconnect task. The framework's normal reset and shutdown code had no object to close. That orphaned task could keep `asyncio.run()` shutdown from completing and leave the ECS process alive.

The critical distinction is **initial connection ownership**. Previous fixes correctly cleaned up channels and robust connections after the framework owned them. They could not close an object that `connect_robust` had created internally but never returned.

## Why the previous reliability fixes did not cover this

This PR was developed after reviewing the previous framework and platform rounds. Those changes were valid and remain necessary; each addressed a different failure phase.

### Round 1: established consumer/channel recovery

- [Framework #53](https://github.com/danzanellovossos/ergon-framework/pull/53) fixed zombie consumers caused by broker `Basic.Cancel`, dead-channel references, duplicate robust consumer restoration, leaked channels, long heartbeats, and unbounded ack/nack operations.
- That incident happened **after a connection and channel existed**. The framework had an object it could explicitly close.

### Round 2: bounded multi-subscription lifecycle and task liveness

- [Framework #59](https://github.com/danzanellovossos/ergon-framework/pull/59) bounded reconnect, channel creation, acknowledgements, and transaction execution; added consumer progress signals and independent task supervision.
- [Framework #61](https://github.com/danzanellovossos/ergon-framework/pull/61) improved signal handling, reverse-order cleanup, partial-startup cleanup, and hard-exit supervision.
- [Framework #62](https://github.com/danzanellovossos/ergon-framework/pull/62) made fetch consumers framework-owned, bounded iterator/channel cleanup, separated transient transport errors from permanent topology/authentication errors, and verified recovery after a real broker restart.
- [Platform #223](https://github.com/ergondata-labs/ergon-platform/pull/223) migrated event-streams, automations subscriptions, and bucket folder workers from direct aio-pika loops to that framework lifecycle and released framework 0.1.7 across the platform.
- These changes covered active consumers, broker restarts, and cleanup of objects already returned to the framework. They did not capture aio-pika's connection object before the initial await.

### Round 3: reconnect-timeout shutdown guarantees

- [Framework #64](https://github.com/danzanellovossos/ergon-framework/pull/64) always closed an owned robust connection even when its transport reported closed, bounded close operations, and kept the process hard-exit deadline armed through supervised cleanup.
- [Platform #255](https://github.com/ergondata-labs/ergon-platform/pull/255) deployed that fix as framework 0.1.8 to all platform services.
- This fixed reconnect timeouts for `self._connection`, meaning a robust connection the service already owned. In the current incident, `self._connection` was never assigned because the **first** `connect_robust` call did not return.

### Round 4: persistent consumers, bounded prefetch, and safe concurrency

- [Framework #65](https://github.com/danzanellovossos/ergon-framework/pull/65) added continuous consumer refill.
- [Framework #66](https://github.com/danzanellovossos/ergon-framework/pull/66) replaced per-fetch iterator churn with persistent `basic.consume` registrations.
- [Framework #67](https://github.com/danzanellovossos/ergon-framework/pull/67) required manual acknowledgements, bounded persistent-consumer memory through prefetch, and woke blocked fetches during teardown.
- [Platform #262](https://github.com/ergondata-labs/ergon-platform/pull/262) adopted continuous refill, bounded multi-subscription prefetch, added RabbitMQ health checking to agents, and improved backlog scaling.
- [Platform #269](https://github.com/ergondata-labs/ergon-platform/pull/269) pinned safe per-worker concurrency and prefetch budgets.
- These changes prevent consumer churn, memory growth, and unsafe in-flight delivery counts after startup. They do not change ownership during the first connection attempt.

### Round 5: infrastructure guardrails

- [Platform #115](https://github.com/ergondata-labs/ergon-platform/pull/115) introduced queue-depth metrics and ECS autoscaling.
- [Platform #257](https://github.com/ergondata-labs/ergon-platform/pull/257) increased bucket processor capacity, lowered the backlog-per-task target, and added RabbitMQ connectivity health checks.
- [Platform #303](https://github.com/ergondata-labs/ergon-platform/pull/303) moved all services onto the framework 0.2.x packaging contract.
- These are useful defenses, but a TCP/TLS reachability probe cannot prove that the worker's framework task is still running or that a consumer is registered. Autoscaling is capacity management, not process-lifecycle repair.

All previous fixes remain in place. This PR closes the one lifecycle interval that remained uncovered: **after aio-pika creates the robust connection and reconnect task, but before it returns that connection to Ergon**.

## What this PR changes

### 1. Capture ownership before the first await can fail

`AsyncRabbitMQService._open_owned_robust_connection()` supplies aio-pika's supported `connection_class` factory hook. The factory synchronously records the `RobustConnection` instance at construction time, before `connect_robust` begins awaiting the initial connection.

This gives the framework a cleanup handle even when `connect_robust` never returns.

### 2. Clean up every unsuccessful initial-connect exit

The initial connection remains bounded by the configured `connect_timeout`. On any `BaseException` exit—including timeout, external cancellation, authentication failure, transport error, and shutdown cancellation—the framework calls the existing bounded `_close_connection_safely()` on the captured object before re-raising the original failure.

Catching `BaseException` here is intentional: `asyncio.CancelledError` must perform ownership cleanup and then continue propagating. The exception is not swallowed.

The temporary reference is cleared after close so the exception traceback does not retain the partial connection.

### 3. Preserve successful ownership transfer

On success, `connect_robust` returns the same captured object. `_get_connection()` assigns it to `self._connection`, and all existing reconnect, channel, consume, publish, and service-close behavior continues unchanged.

There is no second connection, no wrapper object, and no change to queue topology or message settlement.

### 4. Correct Python 3.10 timeout handling

The framework previously caught unqualified `TimeoutError` in several async timeout paths. On Python 3.10, `asyncio.TimeoutError` is distinct from `builtins.TimeoutError`, so those handlers could be bypassed even though they worked on newer runtimes where the classes are aliases.

This PR explicitly uses `asyncio.TimeoutError` for:

- initial and established robust-connection timeouts;
- bounded robust-connection close;
- consume- and publish-channel creation;
- bounded delivery polling;
- dead-channel timeout classification for ack/nack; and
- async transaction processing timeouts.

This is required for the framework's declared Python 3.10 compatibility and was validated at runtime, not only by source inspection.

### 5. Release as framework 0.2.3

The package metadata, runtime `ergon.__version__`, and smoke contract are bumped from 0.2.1 to 0.2.3.

## Failure scenarios covered

The regression suite now verifies all ownership transitions relevant to this defect:

- the initial connection hangs until the framework deadline;
- the caller cancels the initial connection attempt;
- the initial attempt raises a permanent error such as invalid credentials;
- a successful initial connection transfers ownership to the service and closes exactly once during service shutdown;
- a retry after a timed-out initial attempt creates a fresh connection and does not reuse the failed object;
- a real TCP server accepts the client socket but never completes the AMQP handshake;
- aio-pika's internal reconnect task is released after the real handshake timeout;
- the partial client socket reaches EOF before server-side test cleanup on production/current Python runtimes;
- existing robust-connection reconnect timeouts still reset the service connection;
- robust close remains bounded even when transport cleanup hangs; and
- Python 3.10 raises and handles `asyncio.TimeoutError` through the intended recovery paths.

The test doubles intentionally model aio-pika's ownership boundary: connection construction and reconnect-task startup occur before `connect_robust` returns.

## Compatibility and implementation review

The implementation was checked against the connection lifecycle used by aio-pika 9.0.0 and the platform-locked 9.6.2. aio-pika 10.0.1 semantics were also inspected for forward compatibility. The fix uses aio-pika's exposed `connection_class` factory boundary rather than mutating its private reconnect internals.

The real handshake regression uses aio-pika itself, not only mocks. It proves that cleanup releases the internal reconnect task and, on production/current runtimes, the client TCP connection before the test closes the server side.

## Verification completed

- [x] Complete framework suite on the current runtime: `uv run pytest -q` — **462 passed**
- [x] Complete RabbitMQ service suite on Python 3.10 — **59 passed**
- [x] Real aio-pika blackholed-handshake regression on Python 3.10
- [x] Real aio-pika blackholed-handshake regression on Python 3.12
- [x] Real aio-pika blackholed-handshake regression on the current Python runtime
- [x] Ruff checks for the changed implementation and tests
- [x] Pyright checks for the changed implementation and tests — **0 errors**
- [x] Built framework 0.2.3 wheel
- [x] Installed/smoke-tested the 0.2.3 wheel in the platform `agents`, `automations`, and `buckets` service environments
- [x] Reviewed the final diff specifically for startup timeout, cancellation, cleanup, retry, socket, and cross-version regressions

## What this PR intentionally does not change

- No queue, exchange, routing, DLX, prefetch, concurrency, acknowledgement, or retry semantics change.
- No platform worker application code changes are required for the ownership fix.
- No autoscaling thresholds or ECS health-check definitions change in this repository.
- Existing established-connection recovery and hard-exit supervision remain in place as independent defenses.

A richer application-level worker health signal would still be useful because a network reachability probe cannot detect every future consumer-loop failure. That is defense in depth and should not substitute for deterministic connection ownership and cleanup.

## Rollout after merge

1. Merge this PR and publish/tag `ergon-framework-python` 0.2.3.
2. Update the framework constraints and lockfiles in `ergon-platform` to 0.2.3.
3. Rebuild and redeploy the RabbitMQ-dependent worker images so running ECS task definitions contain the new wheel.
4. Confirm the deployed containers report `ergon.__version__ == "0.2.3"`.
5. During the next broker interruption or controlled connection-failure test, verify that failed startup tasks exit and ECS replaces them instead of leaving running non-consumers.
6. Monitor `MessagesReady`, `MessagesUnacked`, ECS running/desired counts, worker startup errors, and replacement-task events during rollout.

A platform lock bump plus image rebuild/redeploy is sufficient to adopt the framework fix; no service-specific behavior patch is required.

## Reviewer focus

Please review especially:

- whether the `connection_class` capture occurs before every aio-pika await that can fail;
- cleanup behavior under `asyncio.CancelledError` and timeout;
- bounded close behavior if the partial connection itself is wedged;
- successful ownership transfer and avoidance of double-close;
- Python 3.10 `asyncio.TimeoutError` handling; and
- the real blackholed-handshake test's proof that reconnect-task and socket cleanup are not hidden by test teardown.