### PR TITLE
chore(release): cut 0.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install ergon-framework-python
 Connector integrations are optional. Install only the ones your application uses:
 
 ```bash
-pip install 'ergon-framework-python[rabbitmq,postgres]'
+pip install 'ergon-framework-python[rabbitmq,postgres,outlook]'
 ```
 
 ### Running Tasks

--- a/docs/modules/3.connector.md
+++ b/docs/modules/3.connector.md
@@ -373,6 +373,7 @@ config = ConnectorConfig(
 ```
 
 See the [Outlook connector module README](../../sdks/python/src/ergon/connector/outlook/README.md)
+and the [runnable Outlook example](../../sdks/python/examples/outlook/)
 for Graph permissions, sending messages, and direct service usage.
 
 ### Ergon Platform

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -27,7 +27,46 @@ pip install 'ergon-framework-python[all]'
 Available extras are `rabbitmq`, `sqs`, `postgres`, `pipefy`, `excel`,
 `ergon-platform`, `nylas`, and `outlook`.
 
-For local development, install in editable mode:
+### Outlook / Microsoft Graph
+
+```bash
+pip install 'ergon-framework-python[outlook]'
+```
+
+The Outlook connector talks to Microsoft Graph with Entra **application**
+credentials. Consuming messages and attachments needs `Mail.Read`; marking,
+categorizing, moving, and deleting need `Mail.ReadWrite`; send, reply, and
+forward need `Mail.Send`. Graph `$filter` and `$search` cannot be combined.
+
+```python
+from ergon.connector.outlook import (
+    AsyncOutlookGraphConnector,
+    OutlookAckActionConfig,
+    OutlookConsumerConfig,
+    OutlookGraphClient,
+    OutlookMessageFilter,
+)
+
+client = OutlookGraphClient(
+    tenant_id="...",
+    client_id="...",
+    client_secret="...",
+    user_email="mailbox@example.com",
+)
+consumer = OutlookConsumerConfig(
+    folder_id="Inbox",
+    filter=OutlookMessageFilter(unread_only=True, has_attachments=True),
+    download_attachments=True,
+    ack_config=OutlookAckActionConfig(mark_as_read=True),
+)
+```
+
+Runnable example: [examples/outlook](https://github.com/danzanellovossos/ergon-framework/tree/main/sdks/python/examples/outlook).
+Module reference: [Outlook connector README](https://github.com/danzanellovossos/ergon-framework/blob/main/sdks/python/src/ergon/connector/outlook/README.md).
+
+### Local development
+
+Install in editable mode:
 
 ```bash
 pip install -e /path/to/ergon-framework/sdks/python

--- a/sdks/python/examples/outlook/README.md
+++ b/sdks/python/examples/outlook/README.md
@@ -1,5 +1,13 @@
 # Exemplo — Outlook / Microsoft Graph
 
+Instalação via PyPI:
+
+```bash
+pip install 'ergon-framework-python[outlook]'
+```
+
+No repositório do SDK:
+
 ```bash
 cd sdks/python
 uv sync --extra outlook

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ergon-framework-python"
-version = "0.2.3"
+version = "0.2.4"
 description = "Ergon internal task-oriented project bootstrapper"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/src/ergon/__init__.py
+++ b/sdks/python/src/ergon/__init__.py
@@ -10,4 +10,4 @@ __all__ = [
     "manager",
 ]
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/sdks/python/src/ergon/connector/outlook/README.md
+++ b/sdks/python/src/ergon/connector/outlook/README.md
@@ -15,6 +15,8 @@ A superfície do SDK cobre leitura, envio e mutações de mensagem com
 pip install 'ergon-framework-python[outlook]'
 ```
 
+Exemplo executável: [`examples/outlook/`](../../../../examples/outlook/)
+
 ## Permissões
 
 O aplicativo Entra precisa de permissões **Application** com admin consent:

--- a/sdks/python/tests/test_smoke.py
+++ b/sdks/python/tests/test_smoke.py
@@ -4,4 +4,4 @@ import ergon
 
 
 def test_ergon_package_is_importable() -> None:
-    assert ergon.__version__ == "0.2.3"
+    assert ergon.__version__ == "0.2.4"


### PR DESCRIPTION
## Summary
- Bump `ergon-framework-python` to **0.2.4** so the Outlook Graph connector from #78 can be published (PyPI 0.2.3 was tagged before that merge).
- Document the `[outlook]` extra, Entra Graph permissions, and the [examples/outlook](https://github.com/danzanellovossos/ergon-framework/tree/main/sdks/python/examples/outlook) on the package README (PyPI long description).

## Test plan
- [ ] Tag `v0.2.4` after merge; `release.yml` publishes to PyPI
- [ ] `pip install 'ergon-framework-python[outlook]==0.2.4'` imports `ergon.connector.outlook`


Made with [Cursor](https://cursor.com)